### PR TITLE
Reconfigure taskfile to avoid global golint dependency

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,7 +61,9 @@ tasks:
     desc: Lint Go code
     cmds:
       - go vet {{ default .DEFAULT_PACKAGES .PACKAGES }}
-      - "'{{.GOLINTBIN}}' {{.GOLINTFLAGS}} {{ default .DEFAULT_TARGETS .TARGETS }}"
+      - |
+        GOLINT_PATH="$(go list -f '{{"{{"}}.Target{{"}}"}}' golang.org/x/lint/golint || echo "false")"
+        "$GOLINT_PATH" {{.GOLINTFLAGS}} "{{ default .DEFAULT_TARGETS .TARGETS }}"
 
   go:check-formatting:
     desc: Check Go code formatting
@@ -181,8 +183,6 @@ vars:
     sh: echo '`go list -f '{{"{{"}}.Dir{{"}}"}}' ./...`'
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
 
-  GOLINTBIN:
-    sh: go list -f {{"{{"}}".Target{{"}}"}}" golang.org/x/lint/golint
   GOLINTFLAGS: "-min_confidence 0.8 -set_exit_status"
 
   PRETTIER: prettier@2.1.2


### PR DESCRIPTION
The previous approach for defining the `GOLINTBIN` variable caused any use of task to fail if `golint` was not installed, even though the task being run might have nothing to do with `golint`.

There are multiple alternative fixes for this, but since the `GOLINTBIN` variable was only used in a single task, and I don't foresee it being needed in additional tasks, it seemed easiest to just do away with the variable altogether.