### PR TITLE
Add CI workflow to lint documentation files

### DIFF
--- a/.github/workflows/lint-documentation.yml
+++ b/.github/workflows/lint-documentation.yml
@@ -1,0 +1,43 @@
+name: Lint documentation files
+
+on:
+  push:
+    paths:
+      - ".github/workflows/lint-documentation.yml"
+      - "Taskfile.yml"
+      # Recognized license files. See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
+      - "COPYING*"
+      - "LICENCE*"
+      - "LICENSE*"
+  pull_request:
+    paths:
+      - ".github/workflows/lint-documentation.yml"
+      - "Taskfile.yml"
+      - "COPYING*"
+      - "LICENCE*"
+      - "LICENSE*"
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby  # Install latest version
+
+      - name: Install licensee
+        run: gem install licensee
+
+      # See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository
+      - name: Check license file
+        run: task --silent docs:check-license


### PR DESCRIPTION
Currently checks the license file.

I find it to be a common problem that license files are not formatted correctly to allow GitHub to automatically detect the license type, which is used in searches, the API, and the repository home page and license page:
https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository

Several license filenames are supported, so it's possible for a file added to the repository to inadvertently override the intended license file.