### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Run tests
+
+on:
+  push:
+    paths:
+      - ".github/workflows/test.yml"
+      - "Taskfile.yml"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+      - "**/testdata/**"
+  pull_request:
+    paths:
+      - ".github/workflows/test.yml"
+      - "Taskfile.yml"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+      - "**/testdata/**"
+
+jobs:
+  test-go:
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+
+    runs-on: ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Build
+        run: task build
+
+      - name: Run unit tests
+        run: task go:test-unit


### PR DESCRIPTION
The workflow is missing the step to upload coverage data to Codecov.io because that will fail unless an upload token is provided (https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token). That would require a secret to be created and I don't have the admin access to do it. Considering the coverage is 0, it's not an urgent matter.

The workflow is missing artifact creation. I need to figure out how to handle that, which may change depending on where we decide to host the schema. For now, I think it's worth just getting a minimal workflow in place and adding to it in subsequent PRs.