### PR TITLE
Make schema.pathURI() produce specification-compliant URIs from Windows paths

### DIFF
--- a/check/checkdata/schema/schema.go
+++ b/check/checkdata/schema/schema.go
@@ -75,7 +75,15 @@ func ValidationErrorMatch(typeQuery string, fieldQuery string, descriptionQueryR
 
 // pathURI returns the URI representation of the path argument.
 func pathURI(path *paths.Path) string {
-	uriFriendlyPath := filepath.ToSlash(path.String())
+	absolutePath, err := path.Abs()
+	if err != nil {
+		panic(err.Error())
+	}
+	uriFriendlyPath := filepath.ToSlash(absolutePath.String())
+	// In order to be valid, the path in the URI must start with `/`, but Windows paths do not.
+	if uriFriendlyPath[0] != '/' {
+		uriFriendlyPath = "/" + uriFriendlyPath
+	}
 	pathURI := url.URL{
 		Scheme: "file",
 		Path:   uriFriendlyPath,

--- a/check/checkdata/schema/schema_test.go
+++ b/check/checkdata/schema/schema_test.go
@@ -1,0 +1,18 @@
+package schema
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathURI(t *testing.T) {
+	switch runtime.GOOS {
+	case "windows":
+		require.Equal(t, "file:///c:/foo%20bar", pathURI(paths.New("c:/foo bar")))
+	default:
+		require.Equal(t, "file:///foo%20bar", pathURI(paths.New("/foo bar")))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/arduino/go-paths-helper v1.3.2
 	github.com/arduino/go-properties-orderedmap v1.4.0
 	github.com/sirupsen/logrus v1.6.0
+	github.com/stretchr/testify v1.6.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 )


### PR DESCRIPTION
The path in a `file` URI must always start with `/`, but Windows paths do not.

The current JSON schema validation package has code to handle the missing slash, but the package that will be transitioned requires the correct format.

I did quite a bit of searching for a canonical Golang way of doing this and was surprised to find nothing.

Reference:
https://docs.microsoft.com/en-us/archive/blogs/ie/file-uris-in-windows#proper-syntax