### PR TITLE
Replace reference to "arduino-cli" in copyright headers

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkconfigurations/checkconfigurations.go
+++ b/check/checkconfigurations/checkconfigurations.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkdata/checkdata.go
+++ b/check/checkdata/checkdata.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkdata/library.go
+++ b/check/checkdata/library.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkdata/schema/schema.go
+++ b/check/checkdata/schema/schema.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkfunctions/checkfunctions.go
+++ b/check/checkfunctions/checkfunctions.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkfunctions/library.go
+++ b/check/checkfunctions/library.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkfunctions/sketch.go
+++ b/check/checkfunctions/sketch.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checklevel/checklevel.go
+++ b/check/checklevel/checklevel.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkresult/checkresult.go
+++ b/check/checkresult/checkresult.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/configuration/checkmode/checkmode.go
+++ b/configuration/checkmode/checkmode.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/library/library.go
+++ b/project/library/library.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/library/libraryproperties/libraryproperties.go
+++ b/project/library/libraryproperties/libraryproperties.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/packageindex/packageindex.go
+++ b/project/packageindex/packageindex.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/platform/platform.go
+++ b/project/platform/platform.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/project.go
+++ b/project/project.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/projecttype/projecttype.go
+++ b/project/projecttype/projecttype.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/sketch/sketch.go
+++ b/project/sketch/sketch.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/result/feedback/feedback.go
+++ b/result/feedback/feedback.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/result/outputformat/outputformat.go
+++ b/result/outputformat/outputformat.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/result/result.go
+++ b/result/result.go
@@ -3,7 +3,7 @@
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-cli.
+// which covers the main part of arduino-check.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //


### PR DESCRIPTION
I was not cautious enough in my copy/paste from the Arduino CLI code and missed replacing a reference.