### PR TITLE
Set schemas path relative to executable

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -99,6 +99,9 @@ func TargetPath() *paths.Path {
 
 // SchemasPath returns the path to the folder containing the JSON schemas.
 func SchemasPath() *paths.Path {
-	workingPath, _ := os.Getwd()
-	return paths.New(workingPath)
+	executablePath, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	return paths.New(executablePath).Parent()
 }


### PR DESCRIPTION
Previously, the schemas path was defined relative to the working directory, but the schemas will be stored in a path
relative to the `arduino-check` executable, which may not necessarily be in the working directory.

Unfortunately, this breaks the ability to run the code using `go run` because the executable path is the temporary directory the program is run from and the schemas are not under that path. I did some searching for a solution to this and found none worth consideration (example: `https://github.com/golang/go/issues/5157`, https://stackoverflow.com/questions/18537257/how-to-get-the-directory-of-the-currently-running-file).

I would welcome any suggestions for how to properly handle defining the path to data files that accompany the tool.