### PR TITLE
Add schemas path parameter to libraryproperties.Validate()

### DIFF
--- a/check/checkdata/library.go
+++ b/check/checkdata/library.go
@@ -16,6 +16,7 @@
 package checkdata
 
 import (
+	"github.com/arduino/arduino-check/configuration"
 	"github.com/arduino/arduino-check/project"
 	"github.com/arduino/arduino-check/project/library/libraryproperties"
 	"github.com/arduino/go-properties-orderedmap"
@@ -29,7 +30,7 @@ func InitializeForLibrary(project project.Type) {
 		// TODO: can I even do this?
 		libraryPropertiesSchemaValidationResult = nil
 	} else {
-		libraryPropertiesSchemaValidationResult = libraryproperties.Validate(libraryProperties)
+		libraryPropertiesSchemaValidationResult = libraryproperties.Validate(libraryProperties, configuration.SchemasPath())
 	}
 }
 

--- a/project/library/libraryproperties/libraryproperties.go
+++ b/project/library/libraryproperties/libraryproperties.go
@@ -18,7 +18,6 @@ package libraryproperties
 
 import (
 	"github.com/arduino/arduino-check/check/checkdata/schema"
-	"github.com/arduino/arduino-check/configuration"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
 	"github.com/ory/jsonschema/v3"
@@ -34,9 +33,9 @@ func Properties(libraryPath *paths.Path) (*properties.Map, error) {
 }
 
 // Validate validates library.properties data against the JSON schema.
-func Validate(libraryProperties *properties.Map) *jsonschema.ValidationError {
+func Validate(libraryProperties *properties.Map, schemasPath *paths.Path) *jsonschema.ValidationError {
 	referencedSchemaFilenames := []string{}
-	schemaObject := schema.Compile("arduino-library-properties-schema.json", referencedSchemaFilenames, configuration.SchemasPath())
+	schemaObject := schema.Compile("arduino-library-properties-schema.json", referencedSchemaFilenames, schemasPath)
 
-	return schema.Validate(libraryProperties, schemaObject, configuration.SchemasPath())
+	return schema.Validate(libraryProperties, schemaObject, schemasPath)
 }


### PR DESCRIPTION
The addition of a schemas path parameter to `schema.Validate()` (https://github.com/arduino/arduino-check/pull/14#pullrequestreview-523186487) necessitates doing the same for this function in order to use it in tests.

