### PR TITLE
Add full schema pointer matching capability to schema.ValidationErrorMatch()

### DIFF
--- a/check/checkdata/schema/schema.go
+++ b/check/checkdata/schema/schema.go
@@ -155,7 +155,7 @@ func logValidationError(validationError *jsonschema.ValidationError, schemasPath
 	logrus.Tracef("Instance pointer: %v", validationError.InstancePtr)
 	logrus.Tracef("Schema URL: %s", validationError.SchemaURL)
 	logrus.Tracef("Schema pointer: %s", validationError.SchemaPtr)
-	logrus.Tracef("Schema pointer value: %v", schemaPointerValue(validationError, schemasPath))
+	logrus.Tracef("Schema pointer value: %v", validationErrorSchemaPointerValue(validationError, schemasPath))
 	logrus.Tracef("Failure context: %v", validationError.Context)
 	logrus.Tracef("Failure context type: %T", validationError.Context)
 
@@ -165,10 +165,15 @@ func logValidationError(validationError *jsonschema.ValidationError, schemasPath
 	}
 }
 
+// validationErrorSchemaPointerValue returns the object identified by the validation error's schema JSON pointer.
+func validationErrorSchemaPointerValue(validationError *jsonschema.ValidationError, schemasPath *paths.Path) interface{} {
+	return schemaPointerValue(validationError.SchemaURL, validationError.SchemaPtr, schemasPath)
+}
+
 // schemaPointerValue returns the object identified by the given JSON pointer from the schema file.
-func schemaPointerValue(validationError *jsonschema.ValidationError, schemasPath *paths.Path) interface{} {
-	schemaPath := schemasPath.Join(path.Base(validationError.SchemaURL))
-	return jsonPointerValue(validationError.SchemaPtr, schemaPath)
+func schemaPointerValue(schemaURL, schemaPointer string, schemasPath *paths.Path) interface{} {
+	schemaPath := schemasPath.Join(path.Base(schemaURL))
+	return jsonPointerValue(schemaPointer, schemaPath)
 }
 
 // jsonPointerValue returns the object identified by the given JSON pointer from the JSON file.

--- a/check/checkdata/schema/schema_test.go
+++ b/check/checkdata/schema/schema_test.go
@@ -1,7 +1,6 @@
 package schema
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 	"runtime"
@@ -155,14 +154,13 @@ func Test_pathURI(t *testing.T) {
 	}
 }
 
-func Test_schemaPointerValue(t *testing.T) {
+func Test_validationErrorSchemaPointerValue(t *testing.T) {
 	validationError := jsonschema.ValidationError{
 		SchemaURL: "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/referenced-schema-1.json",
 		SchemaPtr: "#/definitions/patternObject/pattern",
 	}
 
-	schemaPointerValueInterface := schemaPointerValue(&validationError, schemasPath)
-	fmt.Printf("%T", schemaPointerValueInterface)
+	schemaPointerValueInterface := validationErrorSchemaPointerValue(&validationError, schemasPath)
 	schemaPointerValue, ok := schemaPointerValueInterface.(string)
 	require.True(t, ok)
 	require.Equal(t, "^[a-z]+$", schemaPointerValue)


### PR DESCRIPTION
When a schema validation error is related to one of the logic inversion keywords (`not`, `oneOf`), the schema pointer
path provided in the schema validation package's validation results data does not extend past that keyword.

Capability has now been added for the error to be matched against the full JSON pointers under the problematic keywords.

In combination with structuring the schemas in a manner that puts the logic inversion keywords at the lowest possible
level, this makes it possible to fully determine the cause of a validation failure.