### PR TITLE
Move library.properties schema to dedicated folder

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -103,5 +103,5 @@ func SchemasPath() *paths.Path {
 	if err != nil {
 		panic(err)
 	}
-	return paths.New(executablePath).Parent()
+	return paths.New(executablePath).Parent().Join("etc", "schemas")
 }

--- a/etc/schemas/arduino-library-properties-schema.json
+++ b/etc/schemas/arduino-library-properties-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://github.com/arduino/arduino-check/arduino-library-properties-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-schema.json",
   "title": "Arduino library.properties JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
   "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",


### PR DESCRIPTION
As additional schemas and their tests are added to the repository, it will be useful to have a dedicated folder.