### PR TITLE
Add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # arduino-check
 
-`arduino-check` automatically checks for common problems in your [Arduino](https://www.arduino.cc/) projects:
+`arduino-check` is a command line tool that automatically checks for common problems in your
+[Arduino](https://www.arduino.cc/) projects:
 
 - Sketches
 - Libraries

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,44 @@
+// This file is part of arduino-check.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-check.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+// Package cli defines the arduino-check command line interface.
+package cli
+
+import (
+	"github.com/arduino/arduino-check/command"
+	"github.com/spf13/cobra"
+)
+
+// Root creates a new arduino-check command root.
+func Root() *cobra.Command {
+	rootCommand := &cobra.Command{
+		Short:                 "Linter for Arduino projects.",
+		Long:                  "arduino-check checks specification compliance and for other common problems with Arduino projects",
+		DisableFlagsInUseLine: true,
+		Use:                   "arduino-check [FLAG]... PROJECT_PATH\n\nRun checks on PROJECT_PATH.",
+		Run:                   command.ArduinoCheck,
+	}
+
+	rootCommand.PersistentFlags().String("format", "text", "The output format, can be {text|json}.")
+	rootCommand.PersistentFlags().String("library-manager", "", "Configure the checks for libraries in the Arduino Library Manager index. Can be {submit|update|false}.\nsubmit: Also run additional checks required to pass before a library is accepted for inclusion in the index.\nupdate: Also run additional checks required to pass before new releases of a library already in the index are accepted.\nfalse: Don't run any Library Manager-specific checks.")
+	rootCommand.PersistentFlags().String("log-format", "text", "The output format for the logs, can be {text|json}.")
+	rootCommand.PersistentFlags().String("log-level", "panic", "Messages with this level and above will be logged. Valid levels are: trace, debug, info, warn, error, fatal, panic")
+	rootCommand.PersistentFlags().Bool("permissive", false, "Only fail when critical issues are detected.")
+	rootCommand.PersistentFlags().String("project-type", "all", "Only check projects of the specified type and their subprojects. Can be {sketch|library|all}.")
+	rootCommand.PersistentFlags().Bool("recursive", true, "Search path recursively for Arduino projects to check. Can be {true|false}.")
+	rootCommand.PersistentFlags().String("report-file", "", "Save a report on the checks to this file.")
+
+	return rootCommand
+}

--- a/command/command.go
+++ b/command/command.go
@@ -1,0 +1,72 @@
+// This file is part of arduino-check.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-check.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+// Package command implements the arduino-check commands.
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/arduino/arduino-check/check"
+	"github.com/arduino/arduino-check/configuration"
+	"github.com/arduino/arduino-check/project"
+	"github.com/arduino/arduino-check/result"
+	"github.com/arduino/arduino-check/result/feedback"
+	"github.com/arduino/arduino-check/result/outputformat"
+	"github.com/spf13/cobra"
+)
+
+// arduinoCheck is the root command function.
+func ArduinoCheck(rootCommand *cobra.Command, cliArguments []string) {
+	if err := configuration.Initialize(rootCommand.Flags(), cliArguments); err != nil {
+		feedback.Errorf("Configuration error: %v", err)
+		os.Exit(1)
+	}
+
+	result.Results.Initialize()
+
+	projects, err := project.FindProjects()
+	if err != nil {
+		feedback.Errorf("Error while finding projects: %v", err)
+		os.Exit(1)
+	}
+
+	for _, project := range projects {
+		check.RunChecks(project)
+	}
+
+	// All projects have been checked, so summarize their check results in the report.
+	result.Results.AddSummary()
+
+	if configuration.OutputFormat() == outputformat.Text {
+		if len(projects) > 1 {
+			// There are multiple projects, print the summary of check results for all projects.
+			fmt.Print(result.Results.SummaryText())
+		}
+	} else {
+		// Print the complete JSON formatted report.
+		fmt.Println(result.Results.JSONReport())
+	}
+
+	if configuration.ReportFilePath() != nil {
+		// Write report file.
+		result.Results.WriteReport()
+	}
+
+	if !result.Results.Passed() {
+		os.Exit(1)
+	}
+}

--- a/configuration/checkmode/checkmode.go
+++ b/configuration/checkmode/checkmode.go
@@ -17,6 +17,9 @@
 package checkmode
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/arduino/arduino-check/project/projecttype"
 	"github.com/sirupsen/logrus"
 )
@@ -33,6 +36,20 @@ const (
 	All                                  // always
 	Default                              // default
 )
+
+// LibraryManagerModeFromString parses the --library-manager flag value and returns the corresponding check mode settings.
+func LibraryManagerModeFromString(libraryManagerModeString string) (bool, bool, error) {
+	switch strings.ToLower(libraryManagerModeString) {
+	case "submit":
+		return true, false, nil
+	case "update":
+		return false, true, nil
+	case "false":
+		return false, false, nil
+	default:
+		return false, false, fmt.Errorf("No matching Library Manager mode for string %s", libraryManagerModeString)
+	}
+}
 
 // Modes merges the default check mode values for the given superproject type with any user-specified check mode settings.
 func Modes(defaultCheckModes map[projecttype.Type]map[Type]bool, customCheckModes map[Type]bool, superprojectType projecttype.Type) map[Type]bool {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -17,42 +17,96 @@
 package configuration
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/arduino/arduino-check/configuration/checkmode"
 	"github.com/arduino/arduino-check/project/projecttype"
 	"github.com/arduino/arduino-check/result/outputformat"
 	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 )
 
-// TODO: will it be possible to use init() instead?
 // Initialize sets up the tool configuration according to defaults and user-specified options.
-func Initialize() {
-	setDefaults()
-	// TODO configuration according to command line input
+func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
+	var err error
+	outputFormatString, _ := flags.GetString("format")
+	outputFormat, err = outputformat.FromString(outputFormatString)
+	if err != nil {
+		return fmt.Errorf("--format flag value %s not valid", outputFormatString)
+	}
+
+	libraryManagerModeString, _ := flags.GetString("library-manager")
+	if libraryManagerModeString != "" {
+		customCheckModes[checkmode.LibraryManagerSubmission], customCheckModes[checkmode.LibraryManagerIndexed], err = checkmode.LibraryManagerModeFromString(libraryManagerModeString)
+		if err != nil {
+			return fmt.Errorf("--library-manager flag value %s not valid", libraryManagerModeString)
+		}
+	}
+
+	logFormatString, _ := flags.GetString("log-format")
+	logFormat, err := logFormatFromString(logFormatString)
+	if err != nil {
+		return fmt.Errorf("--log-format flag value %s not valid", logFormatString)
+	}
+	logrus.SetFormatter(logFormat)
+
+	logLevelString, _ := flags.GetString("log-level")
+	logLevel, err := logrus.ParseLevel(logLevelString)
+	if err != nil {
+		return fmt.Errorf("--log-level flag value %s not valid", logLevelString)
+	}
+	logrus.SetLevel(logLevel)
+
+	customCheckModes[checkmode.Permissive], _ = flags.GetBool("permissive")
+
+	superprojectTypeFilterString, _ := flags.GetString("project-type")
+	superprojectTypeFilter, err = projecttype.FromString(superprojectTypeFilterString)
+	if err != nil {
+		return fmt.Errorf("--project-type flag value %s not valid", superprojectTypeFilterString)
+	}
+
+	recursive, _ = flags.GetBool("recursive")
+
+	// TODO: validate path
+	reportFilePathString, _ := flags.GetString("report-file")
+	reportFilePath = paths.New(reportFilePathString)
+
 	// TODO validate target path value, exit if not found
 	// TODO support multiple paths
-	// TODO validate output format input
+	targetPath = paths.New(projectPaths[0])
 
-	targetPath = paths.New("e:/electronics/arduino/libraries/arduino-check-test-library")
-
-	// customCheckModes[checkmode.Permissive] = false
-	// customCheckModes[checkmode.LibraryManagerSubmission] = false
-	// customCheckModes[checkmode.LibraryManagerIndexed] = false
+	// TODO: set via environment variable
 	// customCheckModes[checkmode.Official] = false
-	// superprojectType = projecttype.All
-
-	outputFormat = outputformat.JSON
-	//reportFilePath = paths.New("report.json")
-
-	logrus.SetLevel(logrus.PanicLevel)
 
 	logrus.WithFields(logrus.Fields{
-		"superproject type filter": SuperprojectTypeFilter(),
-		"recursive":                Recursive(),
-		"projects path":            TargetPath(),
+		"output format":                   OutputFormat(),
+		"Library Manager submission mode": customCheckModes[checkmode.LibraryManagerSubmission],
+		"Library Manager update mode":     customCheckModes[checkmode.LibraryManagerIndexed],
+		"log format":                      logFormatString,
+		"log level":                       logrus.GetLevel().String(),
+		"permissive":                      customCheckModes[checkmode.Permissive],
+		"superproject type filter":        SuperprojectTypeFilter(),
+		"recursive":                       Recursive(),
+		"report file":                     ReportFilePath(),
+		"projects path":                   TargetPath(),
 	}).Debug("Configuration initialized")
+
+	return nil
+}
+
+// logFormatFromString parses the --log-format flag value and returns the corresponding log formatter.
+func logFormatFromString(logFormatString string) (logrus.Formatter, error) {
+	switch strings.ToLower(logFormatString) {
+	case "text":
+		return &logrus.TextFormatter{}, nil
+	case "json":
+		return &logrus.JSONFormatter{}, nil
+	default:
+		return nil, fmt.Errorf("No matching log format for string %s", logFormatString)
+	}
 }
 
 var customCheckModes = make(map[checkmode.Type]bool)

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,0 +1,140 @@
+// This file is part of arduino-check.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-check.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package configuration
+
+import (
+	"testing"
+
+	"github.com/arduino/arduino-check/configuration/checkmode"
+	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-check/result/outputformat"
+	"github.com/arduino/go-paths-helper"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitialize(t *testing.T) {
+	flags := pflag.NewFlagSet("", pflag.ExitOnError)
+	flags.String("format", "text", "")
+	flags.String("library-manager", "", "")
+	flags.String("log-format", "text", "")
+	flags.String("log-level", "panic", "")
+	flags.Bool("permissive", false, "")
+	flags.String("project-type", "all", "")
+	flags.Bool("recursive", true, "")
+	flags.String("report-file", "", "")
+
+	projectPaths := []string{"/foo"}
+
+	flags.Set("format", "foo")
+	assert.Error(t, Initialize(flags, projectPaths))
+
+	flags.Set("format", "text")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, outputformat.Text, OutputFormat())
+
+	flags.Set("format", "json")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, outputformat.JSON, OutputFormat())
+
+	flags.Set("library-manager", "foo")
+	assert.Error(t, Initialize(flags, projectPaths))
+
+	customCheckModes = make(map[checkmode.Type]bool)
+	flags.Set("library-manager", "")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	_, ok := customCheckModes[checkmode.LibraryManagerSubmission]
+	assert.False(t, ok)
+	_, ok = customCheckModes[checkmode.LibraryManagerIndexed]
+	assert.False(t, ok)
+
+	flags.Set("library-manager", "submit")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.True(t, customCheckModes[checkmode.LibraryManagerSubmission])
+	assert.False(t, customCheckModes[checkmode.LibraryManagerIndexed])
+
+	flags.Set("library-manager", "update")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.False(t, customCheckModes[checkmode.LibraryManagerSubmission])
+	assert.True(t, customCheckModes[checkmode.LibraryManagerIndexed])
+
+	flags.Set("library-manager", "false")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.False(t, customCheckModes[checkmode.LibraryManagerSubmission])
+	assert.False(t, customCheckModes[checkmode.LibraryManagerIndexed])
+
+	flags.Set("log-format", "foo")
+	assert.Error(t, Initialize(flags, projectPaths))
+
+	flags.Set("log-format", "text")
+	assert.Nil(t, Initialize(flags, projectPaths))
+
+	flags.Set("log-format", "json")
+	assert.Nil(t, Initialize(flags, projectPaths))
+
+	flags.Set("permissive", "true")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.True(t, customCheckModes[checkmode.Permissive])
+
+	flags.Set("permissive", "false")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.False(t, customCheckModes[checkmode.Permissive])
+
+	flags.Set("project-type", "foo")
+	assert.Error(t, Initialize(flags, projectPaths))
+
+	flags.Set("project-type", "sketch")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, projecttype.Sketch, SuperprojectTypeFilter())
+
+	flags.Set("project-type", "library")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, projecttype.Library, SuperprojectTypeFilter())
+
+	flags.Set("project-type", "platform")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, projecttype.Platform, SuperprojectTypeFilter())
+
+	flags.Set("project-type", "package-index")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, projecttype.PackageIndex, SuperprojectTypeFilter())
+
+	flags.Set("project-type", "all")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, projecttype.All, SuperprojectTypeFilter())
+
+	flags.Set("recursive", "true")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.True(t, Recursive())
+
+	flags.Set("recursive", "false")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.False(t, Recursive())
+
+	flags.Set("report-file", "")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Nil(t, ReportFilePath())
+
+	reportFilePath := paths.New("/bar")
+	flags.Set("report-file", reportFilePath.String())
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, reportFilePath, ReportFilePath())
+
+	reportFilePath = paths.New("/baz")
+	projectPaths = []string{reportFilePath.String()}
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.Equal(t, reportFilePath, TargetPath())
+}

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -20,15 +20,7 @@ package configuration
 import (
 	"github.com/arduino/arduino-check/configuration/checkmode"
 	"github.com/arduino/arduino-check/project/projecttype"
-	"github.com/arduino/arduino-check/result/outputformat"
 )
-
-func setDefaults() {
-	superprojectTypeFilter = projecttype.All
-	recursive = true
-	outputFormat = outputformat.Text
-	// TODO: targetPath defaults to current path
-}
 
 // Default check modes for each superproject type
 // Subprojects use the same check modes as the superproject

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/arduino/go-properties-orderedmap v1.4.0
 	github.com/ory/jsonschema/v3 v3.0.1
 	github.com/sirupsen/logrus v1.6.0
+	github.com/spf13/cobra v1.0.1-0.20200710201246-675ae5f5a98c
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.6.1
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
 )

--- a/main.go
+++ b/main.go
@@ -16,51 +16,16 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/arduino/arduino-check/check"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/result"
+	"github.com/arduino/arduino-check/cli"
 	"github.com/arduino/arduino-check/result/feedback"
-	"github.com/arduino/arduino-check/result/outputformat"
 )
 
 func main() {
-	configuration.Initialize()
-	// Must be called after configuration.Initialize()
-	result.Results.Initialize()
-
-	projects, err := project.FindProjects()
-	if err != nil {
-		feedback.Errorf("Error while finding projects: %v", err)
-		os.Exit(1)
-	}
-
-	for _, project := range projects {
-		check.RunChecks(project)
-	}
-
-	// All projects have been checked, so summarize their check results in the report.
-	result.Results.AddSummary()
-
-	if configuration.OutputFormat() == outputformat.Text {
-		if len(projects) > 1 {
-			// There are multiple projects, print the summary of check results for all projects.
-			fmt.Print(result.Results.SummaryText())
-		}
-	} else {
-		// Print the complete JSON formatted report.
-		fmt.Println(result.Results.JSONReport())
-	}
-
-	if configuration.ReportFilePath() != nil {
-		// Write report file.
-		result.Results.WriteReport()
-	}
-
-	if !result.Results.Passed() {
+	rootCommand := cli.Root()
+	if err := rootCommand.Execute(); err != nil {
+		feedback.Error(err.Error())
 		os.Exit(1)
 	}
 }

--- a/project/projecttype/projecttype.go
+++ b/project/projecttype/projecttype.go
@@ -16,6 +16,11 @@
 // Package projecttype defines the Arduino project types.
 package projecttype
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Type is the type for Arduino project types.
 //go:generate stringer -type=Type -linecomment
 type Type int
@@ -28,6 +33,22 @@ const (
 	All                      // any project type
 	Not                      // N/A
 )
+
+// FromString parses the --project-type flag value and returns the corresponding project type.
+func FromString(projectTypeString string) (Type, error) {
+	projectType, found := map[string]Type{
+		"sketch":        Sketch,
+		"library":       Library,
+		"platform":      Platform,
+		"package-index": PackageIndex,
+		"all":           All,
+	}[strings.ToLower(projectTypeString)]
+
+	if found {
+		return projectType, nil
+	}
+	return Not, fmt.Errorf("No matching project type for string %s", projectTypeString)
+}
 
 // Matches returns whether the receiver project type matches the argument project type
 func (projectTypeA Type) Matches(projectTypeB Type) bool {

--- a/result/outputformat/outputformat.go
+++ b/result/outputformat/outputformat.go
@@ -16,6 +16,11 @@
 // Package projecttype defines the output formats
 package outputformat
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Type is the type for output formats
 //go:generate stringer -type=Type -linecomment
 type Type int
@@ -24,3 +29,16 @@ const (
 	Text Type = iota // text
 	JSON             // JSON
 )
+
+// FromString parses the --format flag value and returns the corresponding output format type.
+func FromString(outputFormatString string) (Type, error) {
+	formatType, found := map[string]Type{
+		"text": Text,
+		"json": JSON,
+	}[strings.ToLower(outputFormatString)]
+
+	if found {
+		return formatType, nil
+	}
+	return Text, fmt.Errorf("No matching output format for string %s", outputFormatString)
+}


### PR DESCRIPTION
```
$ ./arduino-check --help
arduino-check checks specification compliance and for other common problems with Arduino projects

Usage:
  arduino-check [FLAG]... PROJECT_PATH

Run checks on PROJECT_PATH.

Flags:
      --format string            The output format, can be {text|json}. (default "text")
  -h, --help                     help for arduino-check
      --library-manager string   Configure the checks for libraries in the Arduino Library Manager index. Can be {submit|update|false}.
                                 submit: Also run additional checks required to pass before a library is accepted for inclusion in the index.
                                 update: Also run additional checks required to pass before new releases of a library already in the index are accepted.
                                 false: Don't run any Library Manager-specific checks.
      --log-format string        The output format for the logs, can be {text|json}. (default "text")
      --log-level string         Messages with this level and above will be logged. Valid levels are: trace, debug, info, warn, error, fatal, panic (default "panic")
      --permissive               Only fail when critical issues are detected.
      --project-type string      Only check projects of the specified type and their subprojects. Can be {sketch|library|all}. (default "all")
      --recursive                Search path recursively for Arduino projects to check. Can be {true|false}. (default true)
      --report-file string       Save a report on the checks to this file.
```