### PR TITLE
Make library.properties email schema duplicate of the maintainer schema

### DIFF
--- a/etc/schemas/arduino-library-properties-definitions-schema.json
+++ b/etc/schemas/arduino-library-properties-definitions-schema.json
@@ -247,23 +247,11 @@
         }
       },
       "email": {
-        "base": {
-          "object": {
-            "allOf": [
-              {
-                "type": "string"
-              },
-              {
-                "minLength": 1
-              }
-            ]
-          }
-        },
         "permissive": {
           "object": {
             "allOf": [
               {
-                "$ref": "#/definitions/propertiesObjects/email/base/object"
+                "$ref": "#/definitions/propertiesObjects/maintainer/permissive/object"
               }
             ]
           }
@@ -272,7 +260,7 @@
           "object": {
             "allOf": [
               {
-                "$ref": "#/definitions/propertiesObjects/email/base/object"
+                "$ref": "#/definitions/propertiesObjects/maintainer/specification/object"
               }
             ]
           }
@@ -281,7 +269,7 @@
           "object": {
             "allOf": [
               {
-                "$ref": "#/definitions/propertiesObjects/email/specification/object"
+                "$ref": "#/definitions/propertiesObjects/maintainer/strict/object"
               }
             ]
           }

--- a/project/library/libraryproperties/librarypropertiesschemas_test.go
+++ b/project/library/libraryproperties/librarypropertiesschemas_test.go
@@ -335,6 +335,16 @@ func TestPropertiesMaintainerPattern(t *testing.T) {
 	checkPropertyPatternMismatch("maintainer", testTables, t)
 }
 
+func TestPropertiesEmailPattern(t *testing.T) {
+	testTables := []propertyValueTestTable{
+		{"Starts with arduino", "arduinofoo", compliancelevel.Permissive, assert.False},
+		{"Starts with arduino", "arduinofoo", compliancelevel.Specification, assert.True},
+		{"Starts with arduino", "arduinofoo", compliancelevel.Strict, assert.True},
+	}
+
+	checkPropertyPatternMismatch("email", testTables, t)
+}
+
 func TestPropertiesCategoryEnum(t *testing.T) {
 	testTables := []propertyValueTestTable{
 		{"Invalid category", "foo", compliancelevel.Permissive, assert.False},


### PR DESCRIPTION
Since the `email` field is allowed as an alias for the `maintainer` field, the same requirements must apply to both.