### PR TITLE
Allow setting official check mode configuration via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@
 ## Usage
 
 After installing `arduino-check`, run the command `arduino-check --help` for usage documentation.
+
+Set the `ARDUINO_CHECK_OFFICIAL` environment variable to "true" to run the checks that only apply to official Arduino
+projects.

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -19,6 +19,7 @@ package configuration
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/arduino/arduino-check/configuration/checkmode"
@@ -83,8 +84,12 @@ func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
 		return fmt.Errorf("PROJECT_PATH argument %v does not exist", projectPaths[0])
 	}
 
-	// TODO: set via environment variable
-	// customCheckModes[checkmode.Official] = false
+	if officialModeString, ok := os.LookupEnv("ARDUINO_CHECK_OFFICIAL"); ok {
+		customCheckModes[checkmode.Official], err = strconv.ParseBool(officialModeString)
+		if err != nil {
+			return fmt.Errorf("ARDUINO_CHECK_OFFICIAL environment variable value %s not valid", officialModeString)
+		}
+	}
 
 	logrus.WithFields(logrus.Fields{
 		"output format":                   OutputFormat(),

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -133,4 +133,15 @@ func TestInitialize(t *testing.T) {
 	assert.Equal(t, paths.New(projectPaths[0]), TargetPath())
 
 	assert.Error(t, Initialize(flags, []string{"/nonexistent"}))
+
+	os.Setenv("ARDUINO_CHECK_OFFICIAL", "true")
+	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths))
+	assert.True(t, customCheckModes[checkmode.Official])
+
+	os.Setenv("ARDUINO_CHECK_OFFICIAL", "false")
+	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths))
+	assert.False(t, customCheckModes[checkmode.Official])
+
+	os.Setenv("ARDUINO_CHECK_OFFICIAL", "invalid value")
+	assert.Error(t, Initialize(test.ConfigurationFlags(), projectPaths))
 }


### PR DESCRIPTION
Since the official mode should only be used when checking official Arduino projects, I thought it was not a good idea to
add a flag for this setting, since it could cause confusion to the those using the tool to check 3rd party projects, who
have no use for this setting.