### PR TITLE
Validate project path argument

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -74,9 +74,15 @@ func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
 	reportFilePathString, _ := flags.GetString("report-file")
 	reportFilePath = paths.New(reportFilePathString)
 
-	// TODO validate target path value, exit if not found
 	// TODO support multiple paths
 	targetPath = paths.New(projectPaths[0])
+	targetPathExists, err := targetPath.ExistCheck()
+	if err != nil {
+		return fmt.Errorf("Problem processing PROJECT_PATH argument value %v: %v", projectPaths[0], err)
+	}
+	if !targetPathExists {
+		return fmt.Errorf("PROJECT_PATH argument %v does not exist", projectPaths[0])
+	}
 
 	// TODO: set via environment variable
 	// customCheckModes[checkmode.Official] = false

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -16,6 +16,7 @@
 package configuration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/arduino/arduino-check/configuration/checkmode"
@@ -24,12 +25,15 @@ import (
 	"github.com/arduino/arduino-check/util/test"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitialize(t *testing.T) {
 	flags := test.ConfigurationFlags()
 
-	projectPaths := []string{"/foo"}
+	projectPath, err := os.Getwd()
+	require.Nil(t, err)
+	projectPaths := []string{projectPath}
 
 	flags.Set("format", "foo")
 	assert.Error(t, Initialize(flags, projectPaths))
@@ -125,8 +129,8 @@ func TestInitialize(t *testing.T) {
 	assert.Nil(t, Initialize(flags, projectPaths))
 	assert.Equal(t, reportFilePath, ReportFilePath())
 
-	reportFilePath = paths.New("/baz")
-	projectPaths = []string{reportFilePath.String()}
 	assert.Nil(t, Initialize(flags, projectPaths))
-	assert.Equal(t, reportFilePath, TargetPath())
+	assert.Equal(t, paths.New(projectPaths[0]), TargetPath())
+
+	assert.Error(t, Initialize(flags, []string{"/nonexistent"}))
 }


### PR DESCRIPTION
Exit with a helpful error message if the path provided via the `PROJECT_PATH` argument doesn't exist.