### PR TITLE
Fix result package test

### DIFF
--- a/result/result_test.go
+++ b/result/result_test.go
@@ -30,7 +30,9 @@ import (
 func TestWriteReport(t *testing.T) {
 	flags := test.ConfigurationFlags()
 
-	projectPaths := []string{"/foo"}
+	projectPath, err := os.Getwd() // Path to an arbitrary folder that is guaranteed to exist.
+	require.Nil(t, err)
+	projectPaths := []string{projectPath}
 
 	reportFolderPathString, err := ioutil.TempDir("", "arduino-check-result-TestWriteReport")
 	require.Nil(t, err)


### PR DESCRIPTION
At the time the test was written, there was no validation of the project path argument, so a dummy path worked fine, but
now validation has been added so an existing path must be used.

The merge without rebasing of a PR in parallel to [the PR that added the path validation](https://github.com/arduino/arduino-check/pull/32) resulted in a failing "Run tests" CI workflow, which is fixed by this PR.