### PR TITLE
Default PROJECT_PATH argument to current working directory

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -27,7 +27,7 @@ func Root() *cobra.Command {
 		Short:                 "Linter for Arduino projects.",
 		Long:                  "arduino-check checks specification compliance and for other common problems with Arduino projects",
 		DisableFlagsInUseLine: true,
-		Use:                   "arduino-check [FLAG]... PROJECT_PATH...\n\nRun checks on PROJECT_PATH.",
+		Use:                   "arduino-check [FLAG]... [PROJECT_PATH]...\n\nRun checks on PROJECT_PATH or current path if no PROJECT_PATH argument provided.",
 		Run:                   command.ArduinoCheck,
 	}
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -160,6 +160,12 @@ func TestInitializeReportFile(t *testing.T) {
 
 func TestInitializeProjectPath(t *testing.T) {
 	targetPaths = nil
+	assert.Nil(t, Initialize(test.ConfigurationFlags(), []string{}))
+	workingDirectoryPath, err := os.Getwd()
+	require.Nil(t, err)
+	assert.Equal(t, paths.NewPathList(workingDirectoryPath), TargetPaths(), "Default PROJECT_PATH to current working directory")
+
+	targetPaths = nil
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths))
 	assert.Equal(t, paths.NewPathList(projectPaths[0]), TargetPaths())
 


### PR DESCRIPTION
This permits checks to be run with the default settings simply by executing arduino-check from the project folder.