### PR TITLE
Suppress text output when in --format json mode

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -27,15 +27,12 @@ import (
 	"github.com/arduino/arduino-check/project"
 	"github.com/arduino/arduino-check/result"
 	"github.com/arduino/arduino-check/result/feedback"
-	"github.com/arduino/arduino-check/result/outputformat"
 	"github.com/sirupsen/logrus"
 )
 
 // RunChecks runs all checks for the given project and outputs the results.
 func RunChecks(project project.Type) {
-	if configuration.OutputFormat() == outputformat.Text {
-		fmt.Printf("Checking %s in %s\n", project.ProjectType, project.Path)
-	}
+	feedback.Printf("Checking %s in %s\n", project.ProjectType, project.Path)
 
 	checkdata.Initialize(project, configuration.SchemasPath())
 
@@ -52,23 +49,18 @@ func RunChecks(project project.Type) {
 		}
 
 		// Output will be printed after all checks are finished when configured for "json" output format
-		if configuration.OutputFormat() == outputformat.Text {
-			fmt.Printf("Running check %s: ", checkConfiguration.ID)
-		}
+		feedback.Printf("Running check %s: ", checkConfiguration.ID)
+
 		checkResult, checkOutput := checkConfiguration.CheckFunction()
 		reportText := result.Results.Record(project, checkConfiguration, checkResult, checkOutput)
-		if configuration.OutputFormat() == outputformat.Text {
-			fmt.Print(reportText)
-		}
+		feedback.Print(reportText)
 	}
 
 	// Checks are finished for this project, so summarize its check results in the report.
 	result.Results.AddProjectSummary(project)
 
-	if configuration.OutputFormat() == outputformat.Text {
-		// Print the project check results summary.
-		fmt.Print(result.Results.ProjectSummaryText(project))
-	}
+	// Print the project check results summary.
+	feedback.Print(result.Results.ProjectSummaryText(project))
 }
 
 // shouldRun returns whether a given check should be run for the given project under the current tool configuration.

--- a/result/feedback/feedback.go
+++ b/result/feedback/feedback.go
@@ -19,8 +19,22 @@ package feedback
 import (
 	"fmt"
 
+	"github.com/arduino/arduino-check/configuration"
+	"github.com/arduino/arduino-check/result/outputformat"
 	"github.com/sirupsen/logrus"
 )
+
+// Printf behaves like fmt.Printf but only prints when output format is set to `text`.
+func Printf(format string, v ...interface{}) {
+	Print(fmt.Sprintf(format, v...))
+}
+
+// Print behaves like fmt.Print but only prints when output format is set to `text`.
+func Print(message string) {
+	if configuration.OutputFormat() == outputformat.Text {
+		fmt.Printf(message)
+	}
+}
 
 // Errorf behaves like fmt.Printf but also logs the error.
 func Errorf(format string, v ...interface{}) {


### PR DESCRIPTION
A couple prints were not conditional, polluting the machine readable output.