### PR TITLE
Add a --version flag

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   build:
     desc: Build the project
     cmds:
-      - go build -v
+      - go build -v {{.LDFLAGS}}
 
   test:
     desc: Run tests
@@ -181,6 +181,11 @@ vars:
     sh: echo `go list ./... | tr '\n' ' '`
   DEFAULT_PATHS:
     sh: echo '`go list -f '{{"{{"}}.Dir{{"}}"}}' ./...`'
+  # build vars
+  COMMIT:
+    sh: echo "$(git log -n 1 --format=%h)"
+  LDFLAGS: >
+    -ldflags '-X github.com/arduino/arduino-check/configuration.commit={{.COMMIT}}'
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
 
   GOLINTFLAGS: "-min_confidence 0.8 -set_exit_status"

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -39,6 +39,7 @@ func Root() *cobra.Command {
 	rootCommand.PersistentFlags().String("project-type", "all", "Only check projects of the specified type and their subprojects. Can be {sketch|library|all}.")
 	rootCommand.PersistentFlags().Bool("recursive", true, "Search path recursively for Arduino projects to check. Can be {true|false}.")
 	rootCommand.PersistentFlags().String("report-file", "", "Save a report on the checks to this file.")
+	rootCommand.PersistentFlags().Bool("version", false, "Print version.")
 
 	return rootCommand
 }

--- a/command/command.go
+++ b/command/command.go
@@ -17,6 +17,7 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -34,6 +35,24 @@ func ArduinoCheck(rootCommand *cobra.Command, cliArguments []string) {
 	if err := configuration.Initialize(rootCommand.Flags(), cliArguments); err != nil {
 		feedback.Errorf("Configuration error: %v", err)
 		os.Exit(1)
+	}
+
+	if configuration.VersionMode() {
+		if configuration.OutputFormat() == outputformat.Text {
+			fmt.Println(configuration.Version())
+		} else {
+			versionObject := struct {
+				Version string `json:"version"`
+			}{
+				Version: configuration.Version(),
+			}
+			versionJSON, err := json.MarshalIndent(versionObject, "", "  ")
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println(string(versionJSON))
+		}
+		return
 	}
 
 	result.Results.Initialize()

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -81,6 +81,8 @@ func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
 	reportFilePathString, _ := flags.GetString("report-file")
 	reportFilePath = paths.New(reportFilePathString)
 
+	versionMode, _ = flags.GetBool("version")
+
 	if len(projectPaths) == 0 {
 		// Default to using current working directory.
 		workingDirectoryPath, err := os.Getwd()
@@ -172,6 +174,23 @@ var reportFilePath *paths.Path
 // ReportFilePath returns the path to save the report file at.
 func ReportFilePath() *paths.Path {
 	return reportFilePath
+}
+
+var versionMode bool
+
+func VersionMode() bool {
+	return versionMode
+}
+
+var version string
+var commit string
+
+func Version() string {
+	if version == "" {
+		return "0.0.0+" + commit
+	}
+
+	return version
 }
 
 var targetPaths paths.PathList

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -171,6 +171,18 @@ func TestInitializeReportFile(t *testing.T) {
 	assert.Equal(t, reportFilePath, ReportFilePath())
 }
 
+func TestInitializeVersion(t *testing.T) {
+	flags := test.ConfigurationFlags()
+
+	flags.Set("version", "true")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.True(t, VersionMode())
+
+	flags.Set("version", "false")
+	assert.Nil(t, Initialize(flags, projectPaths))
+	assert.False(t, VersionMode())
+}
+
 func TestInitializeProjectPath(t *testing.T) {
 	targetPaths = nil
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), []string{}))
@@ -200,4 +212,11 @@ func TestInitializeOfficial(t *testing.T) {
 
 	os.Setenv("ARDUINO_CHECK_OFFICIAL", "invalid value")
 	assert.Error(t, Initialize(test.ConfigurationFlags(), projectPaths))
+}
+
+func TestVersion(t *testing.T) {
+	commit = "abcd"
+	assert.Equal(t, "0.0.0+"+commit, Version())
+	version = "42.1.2"
+	assert.Equal(t, version, Version())
 }

--- a/util/test/test.go
+++ b/util/test/test.go
@@ -29,6 +29,7 @@ func ConfigurationFlags() *pflag.FlagSet {
 	flags.String("project-type", "all", "")
 	flags.Bool("recursive", true, "")
 	flags.String("report-file", "", "")
+	flags.Bool("version", false, "")
 
 	return flags
 }


### PR DESCRIPTION
If a release version has not been defined, the version will be returned as `0.0.0+<commit hash>`.