### PR TITLE
Fix regex for detecting misspelled library.properties

### DIFF
--- a/check/checkfunctions/library.go
+++ b/check/checkfunctions/library.go
@@ -60,7 +60,7 @@ func MisspelledLibraryPropertiesFileName() (result checkresult.Type, output stri
 	}
 	directoryListing.FilterOutDirs()
 
-	path, found := containsMisspelledPathBaseName(directoryListing, "library.properties", "(?i)^librar(y)|(ie)s?[.-_]?propert(y)|(ie)s?$")
+	path, found := containsMisspelledPathBaseName(directoryListing, "library.properties", "(?i)^librar((y)|(ie))s?[.-_]?propert((y)|(ie))s?$")
 	if found {
 		return checkresult.Fail, path.String()
 	}


### PR DESCRIPTION
The previous paucity of parentheses resulted in the regular expression matching against filenames it was never intended
to, resulting in false positives for things like "library.json".

Fixes https://github.com/arduino/arduino-check/issues/80