### PR TITLE
Make --recursive flag a string input

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -35,7 +35,7 @@ func Root() *cobra.Command {
 	rootCommand.PersistentFlags().String("format", "text", "The output format can be {text|json}.")
 	rootCommand.PersistentFlags().String("library-manager", "", "Configure the checks for libraries in the Arduino Library Manager index. Can be {submit|update|false}.\nsubmit: Also run additional checks required to pass before a library is accepted for inclusion in the index.\nupdate: Also run additional checks required to pass before new releases of a library already in the index are accepted.\nfalse: Don't run any Library Manager-specific checks.")
 	rootCommand.PersistentFlags().String("project-type", "all", "Only check projects of the specified type and their subprojects. Can be {sketch|library|all}.")
-	rootCommand.PersistentFlags().Bool("recursive", true, "Search path recursively for Arduino projects to check. Can be {true|false}.")
+	rootCommand.PersistentFlags().String("recursive", "true", "Search path recursively for Arduino projects to check. Can be {true|false}.")
 	rootCommand.PersistentFlags().String("report-file", "", "Save a report on the checks to this file.")
 	rootCommand.PersistentFlags().BoolP("verbose", "v", false, "Show more information while running checks.")
 	rootCommand.PersistentFlags().Bool("version", false, "Print version and timestamp of the build.")

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -80,7 +80,11 @@ func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
 		return fmt.Errorf("--project-type flag value %s not valid", superprojectTypeFilterString)
 	}
 
-	recursive, _ = flags.GetBool("recursive")
+	recursiveString, _ := flags.GetString("recursive")
+	recursive, err = strconv.ParseBool(recursiveString)
+	if err != nil {
+		return fmt.Errorf("--recursive flag value %s not valid", recursiveString)
+	}
 
 	reportFilePathString, _ := flags.GetString("report-file")
 	reportFilePath = paths.New(reportFilePathString)

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -160,6 +160,9 @@ func TestInitializeProjectType(t *testing.T) {
 func TestInitializeRecursive(t *testing.T) {
 	flags := test.ConfigurationFlags()
 
+	flags.Set("recursive", "foo")
+	assert.Error(t, Initialize(flags, projectPaths))
+
 	flags.Set("recursive", "true")
 	assert.Nil(t, Initialize(flags, projectPaths))
 	assert.True(t, Recursive())

--- a/util/test/test.go
+++ b/util/test/test.go
@@ -27,7 +27,7 @@ func ConfigurationFlags() *pflag.FlagSet {
 	flags.String("log-format", "text", "")
 	flags.String("log-level", "panic", "")
 	flags.String("project-type", "all", "")
-	flags.Bool("recursive", true, "")
+	flags.String("recursive", "true", "")
 	flags.String("report-file", "", "")
 	flags.Bool("verbose", false, "")
 	flags.Bool("version", false, "")


### PR DESCRIPTION
Previously, the `--recursive` flag had a Boolean type. That is logical, since it uses values of true and false. However,
the fact that the default value of this flag is true changes matters. With the other Boolean flags, the default value
is false, so when you want to set it to true you only need to use the flag without a value, as is standard. But with a
default true flag it's necessary to unset the value, which can't be done with a bare flag, so you must pass false to the
flag. You would expect to be able to do this with either a space separator or an equals sign, just like
with the string flags, but the former is not supported:
```
$ ./arduino-check --recursive false
Configuration error: PROJECT_PATH argument false does not exist
```
Only the equals sign syntax is supported (`--recursive=false`).

So I think the UI is more intuitive with this flag a string type, so the behavior is consistent with the other flags.