### PR TITLE
Don't do project discovery when explicitly defined

### DIFF
--- a/project/project_test.go
+++ b/project/project_test.go
@@ -131,6 +131,20 @@ func TestFindProjects(t *testing.T) {
 			},
 		},
 		{
+			"Explicit file",
+			"sketch",
+			"",
+			[]string{libraryPath.Join("Library.h").String()},
+			assert.NoError,
+			[]Type{
+				{
+					Path:             libraryPath,
+					ProjectType:      projecttype.Sketch,
+					SuperprojectType: projecttype.Sketch,
+				},
+			},
+		},
+		{
 			"Sketch folder",
 			"all",
 			"",
@@ -198,6 +212,20 @@ func TestFindProjects(t *testing.T) {
 					Path:             packageIndexFolderPath,
 					ProjectType:      projecttype.PackageIndex,
 					SuperprojectType: projecttype.PackageIndex,
+				},
+			},
+		},
+		{
+			"Explicit folder",
+			"sketch",
+			"false",
+			[]string{libraryPath.String()},
+			assert.NoError,
+			[]Type{
+				{
+					Path:             libraryPath,
+					ProjectType:      projecttype.Sketch,
+					SuperprojectType: projecttype.Sketch,
 				},
 			},
 		},


### PR DESCRIPTION
Previously, the project path discovery and type detection were done even when the user's settings explicitely defined
these things. When the contents of the given path did not contain something slightly resembling a project of the given
type, the process exited.

That behavior is the only one possible when a project is not explicitely defined by the user, but in the case of an
explicit definition, this is an unnecessary short circuiting of the process. The checks can still be run. This will
result in the same exit status as before, but the check results may provide the user with helpful information about why
their project is invalid.