### PR TITLE
Rename tool to final name: arduino-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Build artifacts
-arduino-check
-arduino-check.exe
+arduino-lint
+arduino-lint.exe
 
 # Test artifacts
 coverage_unit.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# arduino-check
+# arduino-lint
 
-`arduino-check` is a command line tool that automatically checks for common problems in your
+`arduino-lint` is a command line tool that automatically checks for common problems in your
 [Arduino](https://www.arduino.cc/) projects:
 
 - Sketches
@@ -8,13 +8,13 @@
 
 ## Usage
 
-After installing `arduino-check`, run the command `arduino-check --help` for usage documentation.
+After installing `arduino-lint`, run the command `arduino-lint --help` for usage documentation.
 
 A few additional configuration options only of use for internal/development use of the tool can be set via environment
 variables:
 
-- `ARDUINO_CHECK_OFFICIAL` - Set to `"true"` to run the checks that only apply to official Arduino projects.
-- `ARDUINO_CHECK_LOG_LEVEL` - Messages with this level and above will be logged.
+- `ARDUINO_LINT_OFFICIAL` - Set to `"true"` to run the checks that only apply to official Arduino projects.
+- `ARDUINO_LINT_LOG_LEVEL` - Messages with this level and above will be logged.
   - Supported values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
-- `ARDUINO_CHECK_LOG_FORMAT` - The output format for the logs.
+- `ARDUINO_LINT_LOG_FORMAT` - The output format for the logs.
   - Supported values: `text`, `json`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -197,7 +197,7 @@ vars:
   TIMESTAMP:
     sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   LDFLAGS: >
-    -ldflags '-X github.com/arduino/arduino-check/configuration.commit={{.COMMIT}} -X github.com/arduino/arduino-check/configuration.buildTimestamp={{.TIMESTAMP}}'
+    -ldflags '-X github.com/arduino/arduino-lint/configuration.commit={{.COMMIT}} -X github.com/arduino/arduino-lint/configuration.buildTimestamp={{.TIMESTAMP}}'
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
 
   GOLINTFLAGS: "-min_confidence 0.8 -set_exit_status"
@@ -206,5 +206,5 @@ vars:
 
   WORKFLOW_SCHEMA_PATH: "$(mktemp -t gha-workflow-schema-XXXXXXXXXX.json)"
 
-  CODESPELL_SKIP_OPTION: '--skip "./.git,./go.mod,./go.sum,./arduino-check,./arduino-check.exe,./check/checkfunctions/testdata/libraries/MisspelledSentenceParagraphValue/library.properties"'
+  CODESPELL_SKIP_OPTION: '--skip "./.git,./go.mod,./go.sum,./arduino-lint,./arduino-lint.exe,./check/checkfunctions/testdata/libraries/MisspelledSentenceParagraphValue/library.properties"'
   CODESPELL_IGNORE_WORDS_OPTION: "--ignore-words ./etc/codespell-ignore-words-list.txt"

--- a/check/check.go
+++ b/check/check.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,14 +19,14 @@ package check
 import (
 	"fmt"
 
-	"github.com/arduino/arduino-check/check/checkconfigurations"
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/result"
-	"github.com/arduino/arduino-check/result/feedback"
+	"github.com/arduino/arduino-lint/check/checkconfigurations"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/result"
+	"github.com/arduino/arduino-lint/result/feedback"
 	"github.com/sirupsen/logrus"
 )
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -18,12 +18,12 @@ package check
 import (
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkconfigurations"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
-	"github.com/arduino/arduino-check/util/test"
+	"github.com/arduino/arduino-lint/check/checkconfigurations"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
+	"github.com/arduino/arduino-lint/util/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/check/checkconfigurations/checkconfigurations.go
+++ b/check/checkconfigurations/checkconfigurations.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -24,9 +24,9 @@ Package checkconfigurations defines the configuration of each check:
 package checkconfigurations
 
 import (
-	"github.com/arduino/arduino-check/check/checkfunctions"
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/check/checkfunctions"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project/projecttype"
 )
 
 // Type is the type for check configurations.

--- a/check/checkconfigurations/checkconfigurations_test.go
+++ b/check/checkconfigurations/checkconfigurations_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/arduino/arduino-check/check"
-	"github.com/arduino/arduino-check/check/checkconfigurations"
-	"github.com/arduino/arduino-check/check/checklevel"
-	"github.com/arduino/arduino-check/configuration/checkmode"
+	"github.com/arduino/arduino-lint/check"
+	"github.com/arduino/arduino-lint/check/checkconfigurations"
+	"github.com/arduino/arduino-lint/check/checklevel"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/check/checkdata/checkdata.go
+++ b/check/checkdata/checkdata.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,9 +20,9 @@ This is for data required by multiple checks.
 package checkdata
 
 import (
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/packageindex"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/packageindex"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 )
 

--- a/check/checkdata/library.go
+++ b/check/checkdata/library.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -21,12 +21,12 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/arduino/arduino-check/check/checkdata/schema"
-	"github.com/arduino/arduino-check/check/checkdata/schema/compliancelevel"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/library/libraryproperties"
-	"github.com/arduino/arduino-check/result/feedback"
 	"github.com/arduino/arduino-cli/arduino/libraries"
+	"github.com/arduino/arduino-lint/check/checkdata/schema"
+	"github.com/arduino/arduino-lint/check/checkdata/schema/compliancelevel"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/library/libraryproperties"
+	"github.com/arduino/arduino-lint/result/feedback"
 	"github.com/arduino/go-properties-orderedmap"
 	"github.com/client9/misspell"
 	"github.com/sirupsen/logrus"

--- a/check/checkdata/packageindex.go
+++ b/check/checkdata/packageindex.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkdata/packageindex_test.go
+++ b/check/checkdata/packageindex_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -18,8 +18,8 @@ package checkdata
 import (
 	"testing"
 
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 )

--- a/check/checkdata/platform.go
+++ b/check/checkdata/platform.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -16,8 +16,8 @@
 package checkdata
 
 import (
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/platform/boardstxt"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/platform/boardstxt"
 	"github.com/arduino/go-properties-orderedmap"
 )
 

--- a/check/checkdata/platform_test.go
+++ b/check/checkdata/platform_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -18,8 +18,8 @@ package checkdata
 import (
 	"testing"
 
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 )

--- a/check/checkdata/schema/compliancelevel/compliancelevel.go
+++ b/check/checkdata/schema/compliancelevel/compliancelevel.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkdata/schema/parsevalidationresult.go
+++ b/check/checkdata/schema/parsevalidationresult.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkdata/schema/schema.go
+++ b/check/checkdata/schema/schema.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/check/checkdata/schema/schema_test.go
+++ b/check/checkdata/schema/schema_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,7 +19,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkdata/schema/testdata"
+	"github.com/arduino/arduino-lint/check/checkdata/schema/testdata"
 	"github.com/arduino/go-properties-orderedmap"
 	"github.com/ory/jsonschema/v3"
 	"github.com/stretchr/testify/require"
@@ -199,14 +199,14 @@ func Test_schemaID(t *testing.T) {
 	require.NotNil(t, err)
 
 	id, err := schemaID("valid-schema.json", testdata.Asset)
-	require.Equal(t, "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/schema-with-references.json", id)
+	require.Equal(t, "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/schema-with-references.json", id)
 	require.Nil(t, err)
 }
 
 func Test_validationErrorSchemaPointerValue(t *testing.T) {
 	validationError := ValidationResult{
 		Result: &jsonschema.ValidationError{
-			SchemaURL: "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/referenced-schema-1.json",
+			SchemaURL: "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/referenced-schema-1.json",
 			SchemaPtr: "#/definitions/patternObject/pattern",
 		},
 		dataLoader: testdata.Asset,

--- a/check/checkdata/schema/schemadata/bindata.go
+++ b/check/checkdata/schema/schemadata/bindata.go
@@ -60,7 +60,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 
 var _arduinoLibraryPropertiesDefinitionsSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-definitions-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-definitions-schema.json",
   "title": "Shared definitions for the Arduino library.properties schemas",
   "type": "object",
   "definitions": {
@@ -942,7 +942,7 @@ func arduinoLibraryPropertiesDefinitionsSchemaJson() (*asset, error) {
 
 var _arduinoLibraryPropertiesPermissiveSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-permissive-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-permissive-schema.json",
   "title": "Arduino library.properties JSON permissive schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the minimum requirements for this file. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
   "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
@@ -1022,7 +1022,7 @@ func arduinoLibraryPropertiesPermissiveSchemaJson() (*asset, error) {
 
 var _arduinoLibraryPropertiesSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-schema.json",
   "title": "Arduino library.properties JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
   "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
@@ -1102,7 +1102,7 @@ func arduinoLibraryPropertiesSchemaJson() (*asset, error) {
 
 var _arduinoLibraryPropertiesStrictSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-strict-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-strict-schema.json",
   "title": "Arduino library.properties strict JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the recommended format. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
   "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
@@ -1182,7 +1182,7 @@ func arduinoLibraryPropertiesStrictSchemaJson() (*asset, error) {
 
 var _generalDefinitionsSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/general-definitions-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/general-definitions-schema.json",
   "title": "Shared definitions",
   "description": "Definitions for use in schemas.",
   "type": "object",

--- a/check/checkdata/schema/testdata/bindata.go
+++ b/check/checkdata/schema/testdata/bindata.go
@@ -82,7 +82,7 @@ func invalidSchemaJson() (*asset, error) {
 
 var _referencedSchema1Json = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/referenced-schema-1.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/referenced-schema-1.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "patternObject": {
@@ -112,7 +112,7 @@ func referencedSchema1Json() (*asset, error) {
 
 var _referencedSchema2Json = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/referenced-schema-2.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/referenced-schema-2.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "minLengthObject": {
@@ -182,7 +182,7 @@ func schemaWithoutIdJson() (*asset, error) {
 
 var _validSchemaWithReferencesJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/schema-with-references.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {
@@ -242,7 +242,7 @@ func validSchemaWithReferencesJson() (*asset, error) {
 
 var _validSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/schema-with-references.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {

--- a/check/checkdata/schema/testdata/input/referenced-schema-1.json
+++ b/check/checkdata/schema/testdata/input/referenced-schema-1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/referenced-schema-1.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/referenced-schema-1.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "patternObject": {

--- a/check/checkdata/schema/testdata/input/referenced-schema-2.json
+++ b/check/checkdata/schema/testdata/input/referenced-schema-2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/referenced-schema-2.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/referenced-schema-2.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "minLengthObject": {

--- a/check/checkdata/schema/testdata/input/valid-schema-with-references.json
+++ b/check/checkdata/schema/testdata/input/valid-schema-with-references.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/schema-with-references.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {

--- a/check/checkdata/schema/testdata/input/valid-schema.json
+++ b/check/checkdata/schema/testdata/input/valid-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/check/checkdata/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/check/checkdata/schema/testdata/schema-with-references.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {

--- a/check/checkdata/sketch.go
+++ b/check/checkdata/sketch.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -16,8 +16,8 @@
 package checkdata
 
 import (
-	"github.com/arduino/arduino-check/project"
 	"github.com/arduino/arduino-cli/arduino/sketches"
+	"github.com/arduino/arduino-lint/project"
 )
 
 // InitializeForSketch gathers the check data for the specified sketch project.

--- a/check/checkfunctions/checkfunctions.go
+++ b/check/checkfunctions/checkfunctions.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -22,9 +22,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project/sketch"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project/sketch"
 	"github.com/arduino/go-paths-helper"
 )
 

--- a/check/checkfunctions/checkfunctions_test.go
+++ b/check/checkfunctions/checkfunctions_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,10 +20,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 )

--- a/check/checkfunctions/library.go
+++ b/check/checkfunctions/library.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -24,14 +24,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkdata/schema"
-	"github.com/arduino/arduino-check/check/checkdata/schema/compliancelevel"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project/library"
-	"github.com/arduino/arduino-check/project/sketch"
 	"github.com/arduino/arduino-cli/arduino/libraries"
 	"github.com/arduino/arduino-cli/arduino/utils"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkdata/schema"
+	"github.com/arduino/arduino-lint/check/checkdata/schema/compliancelevel"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project/library"
+	"github.com/arduino/arduino-lint/project/sketch"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"

--- a/check/checkfunctions/library_test.go
+++ b/check/checkfunctions/library_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"

--- a/check/checkfunctions/packageindex.go
+++ b/check/checkfunctions/packageindex.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -16,8 +16,8 @@
 package checkfunctions
 
 import (
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
 )
 
 // The check functions for package indexes.

--- a/check/checkfunctions/packageindex_test.go
+++ b/check/checkfunctions/packageindex_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,10 +19,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 )

--- a/check/checkfunctions/platform.go
+++ b/check/checkfunctions/platform.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -16,8 +16,8 @@
 package checkfunctions
 
 import (
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
 )
 
 // The check functions for platforms.

--- a/check/checkfunctions/platform_test.go
+++ b/check/checkfunctions/platform_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,10 +19,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 )

--- a/check/checkfunctions/sketch.go
+++ b/check/checkfunctions/sketch.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,10 +20,10 @@ package checkfunctions
 import (
 	"strings"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project/sketch"
 	"github.com/arduino/arduino-cli/arduino/globals"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project/sketch"
 )
 
 // IncorrectSketchSrcFolderNameCase checks for incorrect case of src subfolder name in recursive format libraries.

--- a/check/checkfunctions/sketch_test.go
+++ b/check/checkfunctions/sketch_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,10 +20,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkdata"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/check/checkdata"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 )

--- a/check/checklevel/checklevel.go
+++ b/check/checklevel/checklevel.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,10 +19,10 @@ package checklevel
 import (
 	"fmt"
 
-	"github.com/arduino/arduino-check/check/checkconfigurations"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/configuration/checkmode"
+	"github.com/arduino/arduino-lint/check/checkconfigurations"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
 )
 
 // Type is the type for the check levels.

--- a/check/checklevel/checklevel_test.go
+++ b/check/checklevel/checklevel_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -18,11 +18,11 @@ package checklevel
 import (
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkconfigurations"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/util/test"
+	"github.com/arduino/arduino-lint/check/checkconfigurations"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/util/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/check/checkresult/checkresult.go
+++ b/check/checkresult/checkresult.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -13,22 +13,22 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// Package cli defines the arduino-check command line interface.
+// Package cli defines the arduino-lint command line interface.
 package cli
 
 import (
-	"github.com/arduino/arduino-check/command"
+	"github.com/arduino/arduino-lint/command"
 	"github.com/spf13/cobra"
 )
 
-// Root creates a new arduino-check command root.
+// Root creates a new arduino-lint command root.
 func Root() *cobra.Command {
 	rootCommand := &cobra.Command{
 		Short:                 "Linter for Arduino projects.",
-		Long:                  "arduino-check checks for specification compliance and other common problems with Arduino projects",
+		Long:                  "arduino-lint checks for specification compliance and other common problems with Arduino projects",
 		DisableFlagsInUseLine: true,
-		Use:                   "arduino-check [FLAG]... [PROJECT_PATH]...\n\nRun checks on PROJECT_PATH or current path if no PROJECT_PATH argument provided.",
-		Run:                   command.ArduinoCheck,
+		Use:                   "arduino-lint [FLAG]... [PROJECT_PATH]...\n\nRun checks on PROJECT_PATH or current path if no PROJECT_PATH argument provided.",
+		Run:                   command.ArduinoLint,
 	}
 
 	rootCommand.PersistentFlags().String("compliance", "specification", "Configure how strict the tool is. Can be {strict|specification|permissive}")

--- a/command/command.go
+++ b/command/command.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// Package command implements the arduino-check commands.
+// Package command implements the arduino-lint commands.
 package command
 
 import (
@@ -21,17 +21,17 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/arduino/arduino-check/check"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/result"
-	"github.com/arduino/arduino-check/result/feedback"
-	"github.com/arduino/arduino-check/result/outputformat"
+	"github.com/arduino/arduino-lint/check"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/result"
+	"github.com/arduino/arduino-lint/result/feedback"
+	"github.com/arduino/arduino-lint/result/outputformat"
 	"github.com/spf13/cobra"
 )
 
-// ArduinoCheck is the root command function.
-func ArduinoCheck(rootCommand *cobra.Command, cliArguments []string) {
+// ArduinoLint is the root command function.
+func ArduinoLint(rootCommand *cobra.Command, cliArguments []string) {
 	if err := configuration.Initialize(rootCommand.Flags(), cliArguments); err != nil {
 		feedback.Errorf("Invalid configuration: %v", err)
 		os.Exit(1)

--- a/configuration/checkmode/checkmode.go
+++ b/configuration/checkmode/checkmode.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/sirupsen/logrus"
 )
 
@@ -34,7 +34,7 @@ const (
 	Permissive                           // permissive
 	LibraryManagerSubmission             // submit
 	LibraryManagerIndexed                // update
-	Official                             // ARDUINO_CHECK_OFFICIAL
+	Official                             // ARDUINO_LINT_OFFICIAL
 	Default                              // default
 )
 

--- a/configuration/checkmode/checkmode_test.go
+++ b/configuration/checkmode/checkmode_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/configuration/checkmode/type_string.go
+++ b/configuration/checkmode/type_string.go
@@ -17,9 +17,9 @@ func _() {
 	_ = x[Default-6]
 }
 
-const _Type_name = "strictspecificationpermissivesubmitupdateARDUINO_CHECK_OFFICIALdefault"
+const _Type_name = "strictspecificationpermissivesubmitupdateARDUINO_LINT_OFFICIALdefault"
 
-var _Type_index = [...]uint8{0, 6, 19, 29, 35, 41, 63, 70}
+var _Type_index = [...]uint8{0, 6, 19, 29, 35, 41, 62, 69}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// Package configuration handles the configuration of the arduino-check tool.
+// Package configuration handles the configuration of the arduino-lint tool.
 package configuration
 
 import (
@@ -23,9 +23,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project/projecttype"
-	"github.com/arduino/arduino-check/result/outputformat"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project/projecttype"
+	"github.com/arduino/arduino-lint/result/outputformat"
 	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -57,7 +57,7 @@ func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
 		}
 	}
 
-	if logFormatString, ok := os.LookupEnv("ARDUINO_CHECK_LOG_FORMAT"); ok {
+	if logFormatString, ok := os.LookupEnv("ARDUINO_LINT_LOG_FORMAT"); ok {
 		logFormat, err := logFormatFromString(logFormatString)
 		if err != nil {
 			return fmt.Errorf("--log-format flag value %s not valid", logFormatString)
@@ -66,7 +66,7 @@ func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
 		EnableLogging(true)
 	}
 
-	if logLevelString, ok := os.LookupEnv("ARDUINO_CHECK_LOG_LEVEL"); ok {
+	if logLevelString, ok := os.LookupEnv("ARDUINO_LINT_LOG_LEVEL"); ok {
 		logLevel, err := logrus.ParseLevel(logLevelString)
 		if err != nil {
 			return fmt.Errorf("--log-level flag value %s not valid", logLevelString)
@@ -116,10 +116,10 @@ func Initialize(flags *pflag.FlagSet, projectPaths []string) error {
 		}
 	}
 
-	if officialModeString, ok := os.LookupEnv("ARDUINO_CHECK_OFFICIAL"); ok {
+	if officialModeString, ok := os.LookupEnv("ARDUINO_LINT_OFFICIAL"); ok {
 		customCheckModes[checkmode.Official], err = strconv.ParseBool(officialModeString)
 		if err != nil {
-			return fmt.Errorf("ARDUINO_CHECK_OFFICIAL environment variable value %s not valid", officialModeString)
+			return fmt.Errorf("ARDUINO_LINT_OFFICIAL environment variable value %s not valid", officialModeString)
 		}
 	}
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,10 +19,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project/projecttype"
-	"github.com/arduino/arduino-check/result/outputformat"
-	"github.com/arduino/arduino-check/util/test"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project/projecttype"
+	"github.com/arduino/arduino-lint/result/outputformat"
+	"github.com/arduino/arduino-lint/util/test"
 	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -108,23 +108,23 @@ func TestInitializeLibraryManager(t *testing.T) {
 }
 
 func TestInitializeLogFormat(t *testing.T) {
-	os.Setenv("ARDUINO_CHECK_LOG_FORMAT", "foo")
+	os.Setenv("ARDUINO_LINT_LOG_FORMAT", "foo")
 	assert.Error(t, Initialize(test.ConfigurationFlags(), projectPaths), "Invalid format")
 
-	os.Setenv("ARDUINO_CHECK_LOG_FORMAT", "text")
+	os.Setenv("ARDUINO_LINT_LOG_FORMAT", "text")
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths), "text format")
 
-	os.Setenv("ARDUINO_CHECK_LOG_FORMAT", "json")
+	os.Setenv("ARDUINO_LINT_LOG_FORMAT", "json")
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths), "json format")
 }
 
 func TestInitializeLogLevel(t *testing.T) {
 	require.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths))
 
-	os.Setenv("ARDUINO_CHECK_LOG_LEVEL", "foo")
+	os.Setenv("ARDUINO_LINT_LOG_LEVEL", "foo")
 	assert.Error(t, Initialize(test.ConfigurationFlags(), projectPaths), "Invalid level")
 
-	os.Setenv("ARDUINO_CHECK_LOG_LEVEL", "info")
+	os.Setenv("ARDUINO_LINT_LOG_LEVEL", "info")
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths), "Valid level")
 	assert.Equal(t, logrus.InfoLevel, logrus.GetLevel())
 }
@@ -224,15 +224,15 @@ func TestInitializeOfficial(t *testing.T) {
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths))
 	assert.False(t, customCheckModes[checkmode.Official], "Default official check mode")
 
-	os.Setenv("ARDUINO_CHECK_OFFICIAL", "true")
+	os.Setenv("ARDUINO_LINT_OFFICIAL", "true")
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths))
 	assert.True(t, customCheckModes[checkmode.Official])
 
-	os.Setenv("ARDUINO_CHECK_OFFICIAL", "false")
+	os.Setenv("ARDUINO_LINT_OFFICIAL", "false")
 	assert.Nil(t, Initialize(test.ConfigurationFlags(), projectPaths))
 	assert.False(t, customCheckModes[checkmode.Official])
 
-	os.Setenv("ARDUINO_CHECK_OFFICIAL", "invalid value")
+	os.Setenv("ARDUINO_LINT_OFFICIAL", "invalid value")
 	assert.Error(t, Initialize(test.ConfigurationFlags(), projectPaths))
 }
 

--- a/configuration/defaults.go
+++ b/configuration/defaults.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,8 +20,8 @@ package configuration
 import (
 	"os"
 
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project/projecttype"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project/projecttype"
 )
 
 // Default check modes for each superproject type.

--- a/etc/schemas/arduino-library-properties-definitions-schema.json
+++ b/etc/schemas/arduino-library-properties-definitions-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-definitions-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-definitions-schema.json",
   "title": "Shared definitions for the Arduino library.properties schemas",
   "type": "object",
   "definitions": {

--- a/etc/schemas/arduino-library-properties-permissive-schema.json
+++ b/etc/schemas/arduino-library-properties-permissive-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-permissive-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-permissive-schema.json",
   "title": "Arduino library.properties JSON permissive schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the minimum requirements for this file. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
   "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",

--- a/etc/schemas/arduino-library-properties-schema.json
+++ b/etc/schemas/arduino-library-properties-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-schema.json",
   "title": "Arduino library.properties JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
   "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",

--- a/etc/schemas/arduino-library-properties-strict-schema.json
+++ b/etc/schemas/arduino-library-properties-strict-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/arduino-library-properties-strict-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/arduino-library-properties-strict-schema.json",
   "title": "Arduino library.properties strict JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the recommended format. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
   "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",

--- a/etc/schemas/general-definitions-schema.json
+++ b/etc/schemas/general-definitions-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-check/main/etc/schema/general-definitions-schema.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schema/general-definitions-schema.json",
   "title": "Shared definitions",
   "description": "Definitions for use in schemas.",
   "type": "object",

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/arduino/arduino-check
+module github.com/arduino/arduino-lint
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -18,9 +18,9 @@ package main
 import (
 	"os"
 
-	"github.com/arduino/arduino-check/cli"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/result/feedback"
+	"github.com/arduino/arduino-lint/cli"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/result/feedback"
 )
 
 func init() {

--- a/project/library/library.go
+++ b/project/library/library.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/library/library_test.go
+++ b/project/library/library_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/library/libraryproperties/libraryproperties.go
+++ b/project/library/libraryproperties/libraryproperties.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -17,9 +17,9 @@
 package libraryproperties
 
 import (
-	"github.com/arduino/arduino-check/check/checkdata/schema"
-	"github.com/arduino/arduino-check/check/checkdata/schema/compliancelevel"
-	"github.com/arduino/arduino-check/check/checkdata/schema/schemadata"
+	"github.com/arduino/arduino-lint/check/checkdata/schema"
+	"github.com/arduino/arduino-lint/check/checkdata/schema/compliancelevel"
+	"github.com/arduino/arduino-lint/check/checkdata/schema/schemadata"
 	"github.com/arduino/go-paths-helper"
 	"github.com/arduino/go-properties-orderedmap"
 )

--- a/project/library/libraryproperties/librarypropertiesschemas_test.go
+++ b/project/library/libraryproperties/librarypropertiesschemas_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkdata/schema"
-	"github.com/arduino/arduino-check/check/checkdata/schema/compliancelevel"
-	"github.com/arduino/arduino-check/project/library/libraryproperties"
+	"github.com/arduino/arduino-lint/check/checkdata/schema"
+	"github.com/arduino/arduino-lint/check/checkdata/schema/compliancelevel"
+	"github.com/arduino/arduino-lint/project/library/libraryproperties"
 	"github.com/arduino/go-properties-orderedmap"
 
 	"github.com/stretchr/testify/assert"

--- a/project/packageindex/packageindex.go
+++ b/project/packageindex/packageindex.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/packageindex/packageindex_test.go
+++ b/project/packageindex/packageindex_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/platform/boardstxt/boardstxt.go
+++ b/project/platform/boardstxt/boardstxt.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/platform/platform.go
+++ b/project/platform/platform.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/platform/platform_test.go
+++ b/project/platform/platform_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/project.go
+++ b/project/project.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -19,12 +19,12 @@ package project
 import (
 	"fmt"
 
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/project/library"
-	"github.com/arduino/arduino-check/project/packageindex"
-	"github.com/arduino/arduino-check/project/platform"
-	"github.com/arduino/arduino-check/project/projecttype"
-	"github.com/arduino/arduino-check/project/sketch"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/project/library"
+	"github.com/arduino/arduino-lint/project/packageindex"
+	"github.com/arduino/arduino-lint/project/platform"
+	"github.com/arduino/arduino-lint/project/projecttype"
+	"github.com/arduino/arduino-lint/project/sketch"
 	"github.com/arduino/go-paths-helper"
 	"github.com/sirupsen/logrus"
 )

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,9 +20,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/project/projecttype"
-	"github.com/arduino/arduino-check/util/test"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/project/projecttype"
+	"github.com/arduino/arduino-lint/util/test"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 )

--- a/project/projecttype/projecttype.go
+++ b/project/projecttype/projecttype.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/projecttype/projecttype_test.go
+++ b/project/projecttype/projecttype_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/sketch/sketch.go
+++ b/project/sketch/sketch.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/project/sketch/sketch_test.go
+++ b/project/sketch/sketch_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = "arduino-check"
+name = "arduino-lint"
 version = "0.0.0"
-description = "arduino-check"
+description = "arduino-lint"
 authors = ["Arduino <info@arduino.cc>"]
 
 [tool.poetry.dependencies]

--- a/result/feedback/feedback.go
+++ b/result/feedback/feedback.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/result/outputformat"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/result/outputformat"
 	"github.com/sirupsen/logrus"
 )
 

--- a/result/outputformat/outputformat.go
+++ b/result/outputformat/outputformat.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/result/outputformat/outputformat_test.go
+++ b/result/outputformat/outputformat_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/result/result.go
+++ b/result/result.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"html/template"
 
-	"github.com/arduino/arduino-check/check/checkconfigurations"
-	"github.com/arduino/arduino-check/check/checklevel"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project"
+	"github.com/arduino/arduino-lint/check/checkconfigurations"
+	"github.com/arduino/arduino-lint/check/checklevel"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project"
 	"github.com/arduino/go-paths-helper"
 )
 

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -21,14 +21,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/arduino/arduino-check/check/checkconfigurations"
-	"github.com/arduino/arduino-check/check/checklevel"
-	"github.com/arduino/arduino-check/check/checkresult"
-	"github.com/arduino/arduino-check/configuration"
-	"github.com/arduino/arduino-check/configuration/checkmode"
-	"github.com/arduino/arduino-check/project"
-	"github.com/arduino/arduino-check/project/projecttype"
-	"github.com/arduino/arduino-check/util/test"
+	"github.com/arduino/arduino-lint/check/checkconfigurations"
+	"github.com/arduino/arduino-lint/check/checklevel"
+	"github.com/arduino/arduino-lint/check/checkresult"
+	"github.com/arduino/arduino-lint/configuration"
+	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
+	"github.com/arduino/arduino-lint/util/test"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -287,7 +287,7 @@ func TestAddSummary(t *testing.T) {
 func TestWriteReport(t *testing.T) {
 	flags := test.ConfigurationFlags()
 
-	reportFolderPathString, err := ioutil.TempDir("", "arduino-check-result-TestWriteReport")
+	reportFolderPathString, err := ioutil.TempDir("", "arduino-lint-result-TestWriteReport")
 	require.Nil(t, err)
 	defer os.RemoveAll(reportFolderPathString) // clean up
 	reportFolderPath := paths.New(reportFolderPathString)

--- a/util/test/test.go
+++ b/util/test/test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-check.
+// This file is part of arduino-lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-check.
+// which covers the main part of arduino-lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -13,12 +13,12 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// Package test provides resources for testing arduino-check.
+// Package test provides resources for testing arduino-lint.
 package test
 
 import "github.com/spf13/pflag"
 
-// ConfigurationFlags returns a set of the flags used for command line configuration of arduino-check.
+// ConfigurationFlags returns a set of the flags used for command line configuration of arduino-lint.
 func ConfigurationFlags() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", pflag.ExitOnError)
 	flags.String("compliance", "specification", "")


### PR DESCRIPTION
The previous "arduino-check" was the working title of the project.