### PR TITLE
Use correct template package

### DIFF
--- a/result/result.go
+++ b/result/result.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	"github.com/arduino/arduino-lint/check/checkconfigurations"
 	"github.com/arduino/arduino-lint/check/checklevel"


### PR DESCRIPTION
The previous accidental use of the `html/template` package instead of `text/template` resulted in HTML entity
replacement in the check messages.