### PR TITLE
Base check level on superproject type

### DIFF
--- a/check/checklevel/checklevel.go
+++ b/check/checklevel/checklevel.go
@@ -23,6 +23,7 @@ import (
 	"github.com/arduino/arduino-lint/check/checkresult"
 	"github.com/arduino/arduino-lint/configuration"
 	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project"
 )
 
 // Type is the type for the check levels.
@@ -38,11 +39,11 @@ const (
 )
 
 // CheckLevel determines the check level assigned to the given result of the given check under the current tool configuration.
-func CheckLevel(checkConfiguration checkconfigurations.Type, checkResult checkresult.Type) (Type, error) {
+func CheckLevel(checkConfiguration checkconfigurations.Type, checkResult checkresult.Type, checkedProject project.Type) (Type, error) {
 	if checkResult != checkresult.Fail {
 		return Notice, nil // Level provided by FailCheckLevel() is only relevant for failure result.
 	}
-	configurationCheckModes := configuration.CheckModes(checkConfiguration.ProjectType)
+	configurationCheckModes := configuration.CheckModes(checkedProject.SuperprojectType)
 	return FailCheckLevel(checkConfiguration, configurationCheckModes)
 }
 

--- a/check/checklevel/checklevel_test.go
+++ b/check/checklevel/checklevel_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/arduino/arduino-lint/check/checkresult"
 	"github.com/arduino/arduino-lint/configuration"
 	"github.com/arduino/arduino-lint/configuration/checkmode"
+	"github.com/arduino/arduino-lint/project"
+	"github.com/arduino/arduino-lint/project/projecttype"
 	"github.com/arduino/arduino-lint/util/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -63,7 +65,11 @@ func TestCheckLevel(t *testing.T) {
 			ErrorModes:   testTable.errorModes,
 		}
 
-		level, err := CheckLevel(checkConfiguration, testTable.checkResult)
+		checkedProject := project.Type{
+			SuperprojectType: projecttype.Sketch,
+		}
+
+		level, err := CheckLevel(checkConfiguration, testTable.checkResult, checkedProject)
 		testTable.errorAssertion(t, err, testTable.testName)
 		if err == nil {
 			assert.Equal(t, testTable.expectedLevel, level, testTable.testName)

--- a/result/result.go
+++ b/result/result.go
@@ -90,7 +90,7 @@ func (results *Type) Initialize() {
 
 // Record records the result of a check and returns a text summary for it.
 func (results *Type) Record(checkedProject project.Type, checkConfiguration checkconfigurations.Type, checkResult checkresult.Type, checkOutput string) string {
-	checkLevel, err := checklevel.CheckLevel(checkConfiguration, checkResult)
+	checkLevel, err := checklevel.CheckLevel(checkConfiguration, checkResult, checkedProject)
 	if err != nil {
 		panic(fmt.Errorf("Error while determining check level: %v", err))
 	}

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -101,7 +101,7 @@ func TestRecord(t *testing.T) {
 	assert.Equal(t, checkConfiguration.Brief, checkReport.Brief)
 	assert.Equal(t, checkConfiguration.Description, checkReport.Description)
 	assert.Equal(t, checkResult.String(), checkReport.Result)
-	checkLevel, _ := checklevel.CheckLevel(checkConfiguration, checkResult)
+	checkLevel, _ := checklevel.CheckLevel(checkConfiguration, checkResult, checkedProject)
 	assert.Equal(t, checkLevel.String(), checkReport.Level)
 	assert.Equal(t, checkOutput, checkReport.Message)
 


### PR DESCRIPTION
Previously, the check level was based on the check mode configuration associated with the project type. It should
instead be based on the check mode configuration for the superproject type because different requirements may apply to
subprojects than to standalone projects.