### PR TITLE
Disable ajv-cli strict mode when validating CI workflows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,7 +186,7 @@ tasks:
     desc: Validate GitHub Actions workflows against JSON schema
     cmds:
       - wget --output-document={{ .WORKFLOW_SCHEMA_PATH }} https://json.schemastore.org/github-workflow
-      - npx ajv-cli validate -s {{ .WORKFLOW_SCHEMA_PATH }} -d "./.github/workflows/*.{yml,yaml}"
+      - npx ajv-cli validate --strict=false -s {{ .WORKFLOW_SCHEMA_PATH }} -d "./.github/workflows/*.{yml,yaml}"
 
   config:check-formatting:
     desc: Check formatting of configuration files


### PR DESCRIPTION
The JSON schema for GitHub Actions workflow files from the JSON Schema Store is not passing metaschema validation with
the new release of ajv-cli. It seems the tool now defaults to a "strict" mode and that schema (note: it's an external
resource, not one of arduino-lint's schemas) is not compliant.