### PR TITLE
Make integration test task build before running tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,6 +31,7 @@ tasks:
   test-integration:
     desc: Run integration tests
     cmds:
+      - task: build
       - poetry install --no-root
       - poetry run pytest test
 


### PR DESCRIPTION
This will ensure that the tests are always run against the current state of the code.