### PR TITLE
Use `--library-manager=false` as default

### DIFF
--- a/internal/configuration/defaults.go
+++ b/internal/configuration/defaults.go
@@ -39,7 +39,7 @@ var defaultRuleModes = map[projecttype.Type]map[rulemode.Type]bool{
 		rulemode.Strict:                   false,
 		rulemode.Specification:            true,
 		rulemode.Permissive:               false,
-		rulemode.LibraryManagerSubmission: true,
+		rulemode.LibraryManagerSubmission: false,
 		rulemode.LibraryManagerIndexed:    false,
 		rulemode.Official:                 false,
 	},

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -181,13 +181,18 @@ def test_version(run_command):
 def test_arduino_lint_official(run_command):
     project_path = test_data_path.joinpath("ARDUINO_LINT_OFFICIAL")
 
-    result = run_command(cmd=[project_path])
+    # Test default to ARDUINO_LINT_OFFICIAL="false"
+    result = run_command(cmd=["--library-manager", "submit", project_path])
     assert not result.ok
 
-    result = run_command(cmd=[project_path], custom_env={"ARDUINO_LINT_OFFICIAL": "true"})
+    result = run_command(
+        cmd=["--library-manager", "submit", project_path], custom_env={"ARDUINO_LINT_OFFICIAL": "true"}
+    )
     assert result.ok
 
-    result = run_command(cmd=[project_path], custom_env={"ARDUINO_LINT_OFFICIAL": "false"})
+    result = run_command(
+        cmd=["--library-manager", "submit", project_path], custom_env={"ARDUINO_LINT_OFFICIAL": "false"}
+    )
     assert not result.ok
 
     result = run_command(cmd=[project_path], custom_env={"ARDUINO_LINT_OFFICIAL": "foo"})


### PR DESCRIPTION
Previously, the default check mode for library projects was `--library-manager=submit`. The reasoning was this would
ensure that no incompatibilities with Library Manager would be introduced during the development phase of libraries.

However, the extra checks by default might make the tool less friendly to first time users who already have their
library in Library Manager but aren't using the appropriate setting due to not having read the documentation.

---
As requested at https://github.com/arduino/arduino-lint/commit/5f24a05ed2a6bcc1d3ecf27137ed7d19f2cb74f1