### PR TITLE
Suppress innocuous error message from tag determination

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -191,7 +191,7 @@ tasks:
 
 vars:
   TAG:
-    sh: echo "`git describe --tags --abbrev=0`"
+    sh: echo "`git describe --tags --abbrev=0 2> /dev/null`"
   TIMESTAMP_SHORT:
     sh: echo "{{now | date "20060102"}}"
   VERSION: "{{if .CUSTOM_VERSION}}{{.CUSTOM_VERSION}}-{{.TIMESTAMP_SHORT}}{{else}}{{.TAG}}{{end}}"


### PR DESCRIPTION
The taskfile uses a Git command to get the current tag name. When there is no tag, it produces an error message every time a task is run:
```
fatal: No tags can describe 'a58dfe994fdd94aa98ccc98b327d49f347384c2f'.
Try --always, or create some tags.
```
This error message is expected and doesn't impact the functionality of the taskfile, but it might cause confusion. The
solution is to redirect the stderr from the command to `/dev/null`, which won't affect the functionality since the tag
name is output on stdout.