### PR TITLE
Add separators between the text output for each project

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -80,6 +80,7 @@ func ArduinoLint(rootCommand *cobra.Command, cliArguments []string) {
 
 		// Print the project rule results summary.
 		feedback.Printf("\n%s\n", result.Results.ProjectSummaryText(project))
+		feedback.Print("\n-------------------\n\n")
 	}
 
 	// All projects have been linted, so summarize their rule results in the report.
@@ -88,7 +89,7 @@ func ArduinoLint(rootCommand *cobra.Command, cliArguments []string) {
 	if configuration.OutputFormat() == outputformat.Text {
 		if len(projects) > 1 {
 			// There are multiple projects, print the summary of rule results for all projects.
-			fmt.Printf("\n%s\n", result.Results.SummaryText())
+			fmt.Println(result.Results.SummaryText())
 		}
 	} else {
 		// Print the complete JSON formatted report.

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -32,7 +32,7 @@ import (
 
 // Runner runs all rules for the given project and outputs the results.
 func Runner(project project.Type) {
-	feedback.Printf("\nLinting %s in %s\n", project.ProjectType, project.Path)
+	feedback.Printf("Linting %s in %s\n", project.ProjectType, project.Path)
 
 	projectdata.Initialize(project)
 


### PR DESCRIPTION
Before:
```
$ arduino-lint

Linting sketch in C:\Users\per\go\src\github.com\arduino\arduino-lint\test\testdata\recursive\SpecificationSketch
Rule SD001 result: fail
warning: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes
Rule SD002 result: fail
warning: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 2
Error count: 0
Rules passed: true

Linting sketch in C:\Users\per\go\src\github.com\arduino\arduino-lint\test\testdata\verbose\HasWarnings
Rule SD001 result: fail
warning: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes
Rule SD002 result: fail
warning: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 2
Error count: 0
Rules passed: true

Finished linting projects. Results:
Warning count: 434
Error count: 114
Rules passed: false
```
After:
```
$ arduino-lint
Linting sketch in C:\Users\per\go\src\github.com\arduino\arduino-lint\test\testdata\recursive\SpecificationSketch
Rule SD001 result: fail
warning: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes
Rule SD002 result: fail
warning: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 2
Error count: 0
Rules passed: true

-------------------

Linting sketch in C:\Users\per\go\src\github.com\arduino\arduino-lint\test\testdata\verbose\HasWarnings
Rule SD001 result: fail
warning: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes
Rule SD002 result: fail
warning: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 2
Error count: 0
Rules passed: true

-------------------

Finished linting projects. Results:
Warning count: 434
Error count: 114
Rules passed: false
```