### PR TITLE
Show brief after rule ID in verbose text output

### DIFF
--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -48,7 +48,7 @@ func Runner(project project.Type) {
 		}
 
 		// Output will be printed after all rules are finished when configured for "json" output format.
-		feedback.VerbosePrintf("Running rule %s...\n", ruleConfiguration.ID)
+		feedback.VerbosePrintf("Running rule %s (%s)...\n", ruleConfiguration.ID, ruleConfiguration.Brief)
 
 		ruleResult, ruleOutput := ruleConfiguration.RuleFunction()
 		reportText := result.Results.Record(project, ruleConfiguration, ruleResult, ruleOutput)


### PR DESCRIPTION
The rule brief is a short description of the rule. When arduino-lint is run in `--verbose` mode, the ID of each rule is
displayed. While this serves to show the progress of linting each project, the user will not know the significance of
these IDs, and previously wouldn't get any other context unless the rule was violated (in which case the failure message
is displayed), so it is somewhat cryptic.

Displaying the brief after the rule ID explains the rules that are being run without increasing the volume of output significantly.

---
Before:
```
Running rule SC001...
Rule SC001 result: pass
Running rule SD001...
Rule SD001 result: fail
warning: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes
Running rule SM001...
Rule SM001 result: skipped
notice: No metadata file
```
After:
```
Running rule SC001 (incorrect Arduino.h case)...
Rule SC001 result: pass
Running rule SD001 (no readme)...
Rule SD001 result: fail
warning: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes
Running rule SM001 (invalid sketch.json JSON format)...
Rule SM001 result: skipped
notice: No metadata file
```

---
Note: The wording of the rule briefs will be improved by https://github.com/arduino/arduino-lint/pull/130 (https://github.com/arduino/arduino-lint/pull/130/commits/d4c5e9cade8741b948150465a2cdc14e7d01f44e) to be more suitable for this application, but those improvements won't take effect until https://github.com/arduino/arduino-lint/pull/130 is merged. This PR only implements the mechanics of displaying the rule brief text.