### PR TITLE
Make rule level name text all caps

### DIFF
--- a/internal/rule/rulelevel/rulelevel.go
+++ b/internal/rule/rulelevel/rulelevel.go
@@ -32,10 +32,10 @@ type Type int
 
 // The line comments set the string for each level.
 const (
-	Info    Type = iota // info
-	Warning             // warning
-	Error               // error
-	Notice              // notice
+	Info    Type = iota // INFO
+	Warning             // WARNING
+	Error               // ERROR
+	Notice              // NOTICE
 )
 
 // RuleLevel determines the rule level assigned to the given result of the given rule under the current tool configuration.

--- a/internal/rule/rulelevel/type_string.go
+++ b/internal/rule/rulelevel/type_string.go
@@ -14,7 +14,7 @@ func _() {
 	_ = x[Notice-3]
 }
 
-const _Type_name = "infowarningerrornotice"
+const _Type_name = "INFOWARNINGERRORNOTICE"
 
 var _Type_index = [...]uint8{0, 4, 11, 16, 22}
 


### PR DESCRIPTION
The rule level (e.g., error, warning) is an important component of the output because it provides the significance of the rule result. The previous all lower case text of the rule level names in the output made it not very visually prominent.

---
Before:
```
Linting sketch in C:\Users\per\go\src\github.com\arduino\arduino-lint\test\testdata\compliance\Permissive
Rule SS001 result: fail
error: Sketch file/folder name mismatch. The primary sketch file name must match the folder: Permissive.ino. See: https://arduino.github.io/arduino-cli/latest/sketch-specification/#primary-sketch-file
Rule SD001 result: fail
warning: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes

Finished linting project. Results:
Warning count: 1
Error count: 1
Rules passed: false
```
After:
```
Linting sketch in C:\Users\per\go\src\github.com\arduino\arduino-lint\test\testdata\compliance\Permissive
Rule SS001 result: fail
ERROR: Sketch file/folder name mismatch. The primary sketch file name must match the folder: Permissive.ino. See: https://arduino.github.io/arduino-cli/latest/sketch-specification/#primary-sketch-file
Rule SD001 result: fail
WARNING: No readme found. Please document your sketch. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-readmes

Finished linting project. Results:
Warning count: 1
Error count: 1
Rules passed: false
```