### PR TITLE
Quote password in signing certificate import command

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,7 +58,7 @@ jobs:
           security create-keychain -p ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
           security default-keychain -s ${{ env.KEYCHAIN }}
           security unlock-keychain -p ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
+          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
           security set-key-partition-list -S apple-tool:,apple: -s -k ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
 
       - name: Install gon for code signing and app notarization

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           security create-keychain -p ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
           security default-keychain -s ${{ env.KEYCHAIN }}
           security unlock-keychain -p ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P ${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}
+          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
           security set-key-partition-list -S apple-tool:,apple: -s -k ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
 
       - name: Install gon for code signing and app notarization


### PR DESCRIPTION
The previous unquoted password in the `security import` command used to import the macOS signing certificate resulted in the command failing when the password contained shell-unfriendly characters:
```
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```
Example of failing import from before this change:
https://github.com/arduino/arduino-lint/runs/1660084978?check_suite_focus=true

Demonstration of successful import after this change:
https://github.com/arduino/arduino-lint/runs/1665803188?check_suite_focus=true
Downloadable here: https://downloads.arduino.cc/arduino-lint/nightly/arduino-lint_nightly-20210107_macOS_64bit.tar.gz