### PR TITLE
Fix regex for custom board menu option titles

### DIFF
--- a/etc/schemas/arduino-boards-txt-definitions-schema.json
+++ b/etc/schemas/arduino-boards-txt-definitions-schema.json
@@ -165,7 +165,7 @@
               },
               {
                 "patternProperties": {
-                  "menu\\..+\\..+$": {
+                  "^menu\\.[^.]+\\.[^.]+$": {
                     "$ref": "#/definitions/propertiesObjects/boardIDMenuMenuIDOptionID/permissive/object"
                   },
                   "^[vp]id\\.[0-9]+$": {
@@ -230,7 +230,7 @@
               },
               {
                 "patternProperties": {
-                  "menu\\..+\\..+$": {
+                  "^menu\\.[^.]+\\.[^.]+$": {
                     "$ref": "#/definitions/propertiesObjects/boardIDMenuMenuIDOptionID/specification/object"
                   },
                   "^[vp]id\\.[0-9]+$": {
@@ -295,7 +295,7 @@
               },
               {
                 "patternProperties": {
-                  "menu\\..+\\..+$": {
+                  "^menu\\.[^.]+\\.[^.]+$": {
                     "$ref": "#/definitions/propertiesObjects/boardIDMenuMenuIDOptionID/strict/object"
                   },
                   "^[vp]id\\.[0-9]+$": {

--- a/internal/rule/rulefunction/platform.go
+++ b/internal/rule/rulefunction/platform.go
@@ -245,7 +245,7 @@ func BoardsTxtBoardIDMenuMenuIDOptionIDLTMinLength() (result ruleresult.Type, ou
 		return ruleresult.Skip, "boards.txt has no boards"
 	}
 
-	nonCompliantBoardIDs := boardIDValueLTMinLength("menu\\..+\\..+", compliancelevel.Strict)
+	nonCompliantBoardIDs := boardIDValueLTMinLength("menu\\.[^.]+\\.[^.]+", compliancelevel.Strict)
 
 	if len(nonCompliantBoardIDs) > 0 {
 		return ruleresult.Fail, strings.Join(nonCompliantBoardIDs, ", ")

--- a/internal/rule/schema/schemadata/bindata.go
+++ b/internal/rule/schema/schemadata/bindata.go
@@ -237,7 +237,7 @@ var _arduinoBoardsTxtDefinitionsSchemaJson = []byte(`{
               },
               {
                 "patternProperties": {
-                  "menu\\..+\\..+$": {
+                  "^menu\\.[^.]+\\.[^.]+$": {
                     "$ref": "#/definitions/propertiesObjects/boardIDMenuMenuIDOptionID/permissive/object"
                   },
                   "^[vp]id\\.[0-9]+$": {
@@ -302,7 +302,7 @@ var _arduinoBoardsTxtDefinitionsSchemaJson = []byte(`{
               },
               {
                 "patternProperties": {
-                  "menu\\..+\\..+$": {
+                  "^menu\\.[^.]+\\.[^.]+$": {
                     "$ref": "#/definitions/propertiesObjects/boardIDMenuMenuIDOptionID/specification/object"
                   },
                   "^[vp]id\\.[0-9]+$": {
@@ -367,7 +367,7 @@ var _arduinoBoardsTxtDefinitionsSchemaJson = []byte(`{
               },
               {
                 "patternProperties": {
-                  "menu\\..+\\..+$": {
+                  "^menu\\.[^.]+\\.[^.]+$": {
                     "$ref": "#/definitions/propertiesObjects/boardIDMenuMenuIDOptionID/strict/object"
                   },
                   "^[vp]id\\.[0-9]+$": {


### PR DESCRIPTION
Due to greedy matching, the previous regular expression matched against option properties in addition to the intended
option titles.