### PR TITLE
Show expected and actual values in rule function output test messages

### DIFF
--- a/internal/rule/rulefunction/library_test.go
+++ b/internal/rule/rulefunction/library_test.go
@@ -16,6 +16,7 @@
 package rulefunction
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -60,7 +61,7 @@ func checkLibraryRuleFunction(ruleFunction Type, testTables []libraryRuleFunctio
 
 		result, output := ruleFunction()
 		assert.Equal(t, testTable.expectedRuleResult, result, testTable.testName)
-		assert.True(t, expectedOutputRegexp.MatchString(output), testTable.testName)
+		assert.True(t, expectedOutputRegexp.MatchString(output), fmt.Sprintf("%s (output: %s, assertion regex: %s)", testTable.testName, output, testTable.expectedOutputQuery))
 	}
 }
 

--- a/internal/rule/rulefunction/packageindex_test.go
+++ b/internal/rule/rulefunction/packageindex_test.go
@@ -16,6 +16,7 @@
 package rulefunction
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -55,7 +56,7 @@ func checkPackageIndexRuleFunction(ruleFunction Type, testTables []packageIndexR
 
 		result, output := ruleFunction()
 		assert.Equal(t, testTable.expectedRuleResult, result, testTable.testName)
-		assert.True(t, expectedOutputRegexp.MatchString(output), testTable.testName)
+		assert.True(t, expectedOutputRegexp.MatchString(output), fmt.Sprintf("%s (output: %s, assertion regex: %s)", testTable.testName, output, testTable.expectedOutputQuery))
 	}
 }
 

--- a/internal/rule/rulefunction/platform_test.go
+++ b/internal/rule/rulefunction/platform_test.go
@@ -16,6 +16,7 @@
 package rulefunction
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -58,7 +59,7 @@ func checkPlatformRuleFunction(ruleFunction Type, testTables []platformRuleFunct
 
 		result, output := ruleFunction()
 		assert.Equal(t, testTable.expectedRuleResult, result, testTable.testName)
-		assert.True(t, expectedOutputRegexp.MatchString(output), testTable.testName)
+		assert.True(t, expectedOutputRegexp.MatchString(output), fmt.Sprintf("%s (output: %s, assertion regex: %s)", testTable.testName, output, testTable.expectedOutputQuery))
 	}
 }
 

--- a/internal/rule/rulefunction/rulefunction_test.go
+++ b/internal/rule/rulefunction/rulefunction_test.go
@@ -16,6 +16,7 @@
 package rulefunction
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -56,7 +57,7 @@ func checkRuleFunction(ruleFunction Type, testTables []ruleFunctionTestTable, t 
 
 		result, output := ruleFunction()
 		assert.Equal(t, testTable.expectedRuleResult, result, testTable.testName)
-		assert.True(t, expectedOutputRegexp.MatchString(output), testTable.testName)
+		assert.True(t, expectedOutputRegexp.MatchString(output), fmt.Sprintf("%s (output: %s, assertion regex: %s)", testTable.testName, output, testTable.expectedOutputQuery))
 	}
 }
 

--- a/internal/rule/rulefunction/sketch_test.go
+++ b/internal/rule/rulefunction/sketch_test.go
@@ -16,6 +16,7 @@
 package rulefunction
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -56,7 +57,7 @@ func checkSketchRuleFunction(ruleFunction Type, testTables []sketchRuleFunctionT
 
 		result, output := ruleFunction()
 		assert.Equal(t, testTable.expectedRuleResult, result, testTable.testName)
-		assert.True(t, expectedOutputRegexp.MatchString(output), testTable.testName)
+		assert.True(t, expectedOutputRegexp.MatchString(output), fmt.Sprintf("%s (output: %s, assertion regex: %s)", testTable.testName, output, testTable.expectedOutputQuery))
 	}
 }
 


### PR DESCRIPTION
Previously, the test messages only said that the result was expected to be true, which was not very helpful for
troubleshooting.