### PR TITLE
Update command line help to reflect check->lint terminology change

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -27,15 +27,15 @@ func Root() *cobra.Command {
 		Short:                 "Linter for Arduino projects.",
 		Long:                  "arduino-lint checks for specification compliance and other common problems with Arduino projects",
 		DisableFlagsInUseLine: true,
-		Use:                   "arduino-lint [FLAG]... [PROJECT_PATH]...\n\nRun rules on PROJECT_PATH or current path if no PROJECT_PATH argument provided.",
+		Use:                   "arduino-lint [FLAG]... [PROJECT_PATH]...\n\nLint project in PROJECT_PATH or current path if no PROJECT_PATH argument provided.",
 		Run:                   command.ArduinoLint,
 	}
 
 	rootCommand.PersistentFlags().String("compliance", "specification", "Configure how strict the tool is. Can be {strict|specification|permissive}")
 	rootCommand.PersistentFlags().String("format", "text", "The output format can be {text|json}.")
 	rootCommand.PersistentFlags().String("library-manager", "", "Configure the rules for libraries in the Arduino Library Manager index. Can be {submit|update|false}.\nsubmit: Also run additional rules required to pass before a library is accepted for inclusion in the index.\nupdate: Also run additional rules required to pass before new releases of a library already in the index are accepted.\nfalse: Don't run any Library Manager-specific rules.")
-	rootCommand.PersistentFlags().String("project-type", "all", "Only check projects of the specified type and their subprojects. Can be {sketch|library|platform|all}.")
-	rootCommand.PersistentFlags().Bool("recursive", false, "Search path recursively for Arduino projects to check. Can be {true|false}.")
+	rootCommand.PersistentFlags().String("project-type", "all", "Only lint projects of the specified type and their subprojects. Can be {sketch|library|platform|all}.")
+	rootCommand.PersistentFlags().Bool("recursive", false, "Search path recursively for Arduino projects to lint. Can be {true|false}.")
 	rootCommand.PersistentFlags().String("report-file", "", "Save a report on the rules to this file.")
 	rootCommand.PersistentFlags().BoolP("verbose", "v", false, "Show more information while running rules.")
 	rootCommand.PersistentFlags().Bool("version", false, "Print version and timestamp of the build.")


### PR DESCRIPTION
Some output messages were not switched over when the tool name and associated terminology was changed to using
"lint"/"rule" in place of "check".