### PR TITLE
Update test data schema IDs to reflect their actual path

### DIFF
--- a/internal/rule/schema/schema_test.go
+++ b/internal/rule/schema/schema_test.go
@@ -212,7 +212,7 @@ func Test_schemaID(t *testing.T) {
 	require.NotNil(t, err)
 
 	id, err := schemaID("valid-schema.json", testdata.Asset)
-	require.Equal(t, "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/schema-with-references.json", id)
+	require.Equal(t, "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/valid-schema.json", id)
 	require.Nil(t, err)
 }
 

--- a/internal/rule/schema/testdata/bindata.go
+++ b/internal/rule/schema/testdata/bindata.go
@@ -82,7 +82,7 @@ func invalidSchemaJson() (*asset, error) {
 
 var _referencedSchema1Json = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/referenced-schema-1.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/referenced-schema-1.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "patternObject": {
@@ -112,7 +112,7 @@ func referencedSchema1Json() (*asset, error) {
 
 var _referencedSchema2Json = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/referenced-schema-2.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/referenced-schema-2.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "dependenciesObject": {
@@ -187,7 +187,7 @@ func schemaWithoutIdJson() (*asset, error) {
 
 var _validSchemaWithReferencesJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/valid-schema-with-references.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {
@@ -250,7 +250,7 @@ func validSchemaWithReferencesJson() (*asset, error) {
 
 var _validSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/valid-schema.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {

--- a/internal/rule/schema/testdata/input/referenced-schema-1.json
+++ b/internal/rule/schema/testdata/input/referenced-schema-1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/referenced-schema-1.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/referenced-schema-1.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "patternObject": {

--- a/internal/rule/schema/testdata/input/referenced-schema-2.json
+++ b/internal/rule/schema/testdata/input/referenced-schema-2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/referenced-schema-2.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/referenced-schema-2.json",
   "title": "Schema for use in unit tests",
   "definitions": {
     "dependenciesObject": {

--- a/internal/rule/schema/testdata/input/valid-schema-with-references.json
+++ b/internal/rule/schema/testdata/input/valid-schema-with-references.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/valid-schema-with-references.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {

--- a/internal/rule/schema/testdata/input/valid-schema.json
+++ b/internal/rule/schema/testdata/input/valid-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/schema-with-references.json",
+  "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/internal/rule/schema/testdata/input/valid-schema.json",
   "title": "Schema for use in unit tests",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Since these are only test data, it's not essential that the IDs be correct, but it might lead to confusion.