### PR TITLE
Only require compiler.warning_flags properties in strict mode

### DIFF
--- a/etc/schemas/arduino-platform-txt-definitions-schema.json
+++ b/etc/schemas/arduino-platform-txt-definitions-schema.json
@@ -1089,10 +1089,6 @@
                 "required": [
                   "name",
                   "version",
-                  "compiler.warning_flags.none",
-                  "compiler.warning_flags.default",
-                  "compiler.warning_flags.more",
-                  "compiler.warning_flags.all",
                   "recipe.c.o.pattern",
                   "recipe.cpp.o.pattern",
                   "recipe.S.o.pattern",
@@ -1131,6 +1127,10 @@
               },
               {
                 "required": [
+                  "compiler.warning_flags.none",
+                  "compiler.warning_flags.default",
+                  "compiler.warning_flags.more",
+                  "compiler.warning_flags.all",
                   "compiler.c.extra_flags",
                   "compiler.cpp.extra_flags",
                   "compiler.S.extra_flags",

--- a/internal/project/platform/platformtxt/platformtxtschema_test.go
+++ b/internal/project/platform/platformtxt/platformtxtschema_test.go
@@ -159,20 +159,20 @@ func TestRequired(t *testing.T) {
 		{"version", "version", compliancelevel.Specification, assert.True},
 		{"version", "version", compliancelevel.Strict, assert.True},
 
-		{"compiler.warning_flags.none", "compiler\\.warning_flags\\.none", compliancelevel.Permissive, assert.True},
-		{"compiler.warning_flags.none", "compiler\\.warning_flags\\.none", compliancelevel.Specification, assert.True},
+		{"compiler.warning_flags.none", "compiler\\.warning_flags\\.none", compliancelevel.Permissive, assert.False},
+		{"compiler.warning_flags.none", "compiler\\.warning_flags\\.none", compliancelevel.Specification, assert.False},
 		{"compiler.warning_flags.none", "compiler\\.warning_flags\\.none", compliancelevel.Strict, assert.True},
 
-		{"compiler.warning_flags.default", "compiler\\.warning_flags\\.default", compliancelevel.Permissive, assert.True},
-		{"compiler.warning_flags.default", "compiler\\.warning_flags\\.default", compliancelevel.Specification, assert.True},
+		{"compiler.warning_flags.default", "compiler\\.warning_flags\\.default", compliancelevel.Permissive, assert.False},
+		{"compiler.warning_flags.default", "compiler\\.warning_flags\\.default", compliancelevel.Specification, assert.False},
 		{"compiler.warning_flags.default", "compiler\\.warning_flags\\.default", compliancelevel.Strict, assert.True},
 
-		{"compiler.warning_flags.more", "compiler\\.warning_flags\\.more", compliancelevel.Permissive, assert.True},
-		{"compiler.warning_flags.more", "compiler\\.warning_flags\\.more", compliancelevel.Specification, assert.True},
+		{"compiler.warning_flags.more", "compiler\\.warning_flags\\.more", compliancelevel.Permissive, assert.False},
+		{"compiler.warning_flags.more", "compiler\\.warning_flags\\.more", compliancelevel.Specification, assert.False},
 		{"compiler.warning_flags.more", "compiler\\.warning_flags\\.more", compliancelevel.Strict, assert.True},
 
-		{"compiler.warning_flags.all", "compiler\\.warning_flags\\.all", compliancelevel.Permissive, assert.True},
-		{"compiler.warning_flags.all", "compiler\\.warning_flags\\.all", compliancelevel.Specification, assert.True},
+		{"compiler.warning_flags.all", "compiler\\.warning_flags\\.all", compliancelevel.Permissive, assert.False},
+		{"compiler.warning_flags.all", "compiler\\.warning_flags\\.all", compliancelevel.Specification, assert.False},
 		{"compiler.warning_flags.all", "compiler\\.warning_flags\\.all", compliancelevel.Strict, assert.True},
 
 		{"recipe.c.o.pattern", "recipe\\.c\\.o\\.pattern", compliancelevel.Permissive, assert.True},

--- a/internal/rule/ruleconfiguration/ruleconfiguration.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration.go
@@ -1989,8 +1989,8 @@ var configurations = []Type{
 		DisableModes:     nil,
 		EnableModes:      []rulemode.Type{rulemode.Default},
 		InfoModes:        nil,
-		WarningModes:     nil,
-		ErrorModes:       []rulemode.Type{rulemode.Default},
+		WarningModes:     []rulemode.Type{rulemode.Default},
+		ErrorModes:       []rulemode.Type{rulemode.Strict},
 		RuleFunction:     rulefunction.PlatformTxtCompilerWarningFlagsNoneMissing,
 	},
 	{
@@ -2005,8 +2005,8 @@ var configurations = []Type{
 		DisableModes:     nil,
 		EnableModes:      []rulemode.Type{rulemode.Default},
 		InfoModes:        nil,
-		WarningModes:     nil,
-		ErrorModes:       []rulemode.Type{rulemode.Default},
+		WarningModes:     []rulemode.Type{rulemode.Default},
+		ErrorModes:       []rulemode.Type{rulemode.Strict},
 		RuleFunction:     rulefunction.PlatformTxtCompilerWarningFlagsDefaultMissing,
 	},
 	{
@@ -2021,8 +2021,8 @@ var configurations = []Type{
 		DisableModes:     nil,
 		EnableModes:      []rulemode.Type{rulemode.Default},
 		InfoModes:        nil,
-		WarningModes:     nil,
-		ErrorModes:       []rulemode.Type{rulemode.Default},
+		WarningModes:     []rulemode.Type{rulemode.Default},
+		ErrorModes:       []rulemode.Type{rulemode.Strict},
 		RuleFunction:     rulefunction.PlatformTxtCompilerWarningFlagsMoreMissing,
 	},
 	{
@@ -2037,8 +2037,8 @@ var configurations = []Type{
 		DisableModes:     nil,
 		EnableModes:      []rulemode.Type{rulemode.Default},
 		InfoModes:        nil,
-		WarningModes:     nil,
-		ErrorModes:       []rulemode.Type{rulemode.Default},
+		WarningModes:     []rulemode.Type{rulemode.Default},
+		ErrorModes:       []rulemode.Type{rulemode.Strict},
 		RuleFunction:     rulefunction.PlatformTxtCompilerWarningFlagsAllMissing,
 	},
 	{

--- a/internal/rule/rulefunction/platform.go
+++ b/internal/rule/rulefunction/platform.go
@@ -699,7 +699,7 @@ func PlatformTxtCompilerWarningFlagsNoneMissing() (result ruleresult.Type, outpu
 		return ruleresult.Skip, "Core reference used"
 	}
 
-	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.none", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Specification]) {
+	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.none", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Strict]) {
 		return ruleresult.Fail, ""
 	}
 
@@ -724,7 +724,7 @@ func PlatformTxtCompilerWarningFlagsDefaultMissing() (result ruleresult.Type, ou
 		return ruleresult.Skip, "Core reference used"
 	}
 
-	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.default", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Specification]) {
+	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.default", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Strict]) {
 		return ruleresult.Fail, ""
 	}
 
@@ -749,7 +749,7 @@ func PlatformTxtCompilerWarningFlagsMoreMissing() (result ruleresult.Type, outpu
 		return ruleresult.Skip, "Core reference used"
 	}
 
-	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.more", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Specification]) {
+	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.more", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Strict]) {
 		return ruleresult.Fail, ""
 	}
 
@@ -774,7 +774,7 @@ func PlatformTxtCompilerWarningFlagsAllMissing() (result ruleresult.Type, output
 		return ruleresult.Skip, "Core reference used"
 	}
 
-	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.all", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Specification]) {
+	if schema.RequiredPropertyMissing("compiler\\.warning_flags\\.all", projectdata.PlatformTxtSchemaValidationResult()[compliancelevel.Strict]) {
 		return ruleresult.Fail, ""
 	}
 

--- a/internal/rule/schema/schemadata/bindata.go
+++ b/internal/rule/schema/schemadata/bindata.go
@@ -3630,10 +3630,6 @@ var _arduinoPlatformTxtDefinitionsSchemaJson = []byte(`{
                 "required": [
                   "name",
                   "version",
-                  "compiler.warning_flags.none",
-                  "compiler.warning_flags.default",
-                  "compiler.warning_flags.more",
-                  "compiler.warning_flags.all",
                   "recipe.c.o.pattern",
                   "recipe.cpp.o.pattern",
                   "recipe.S.o.pattern",
@@ -3672,6 +3668,10 @@ var _arduinoPlatformTxtDefinitionsSchemaJson = []byte(`{
               },
               {
                 "required": [
+                  "compiler.warning_flags.none",
+                  "compiler.warning_flags.default",
+                  "compiler.warning_flags.more",
+                  "compiler.warning_flags.all",
                   "compiler.c.extra_flags",
                   "compiler.cpp.extra_flags",
                   "compiler.S.extra_flags",


### PR DESCRIPTION
Even though platforms should be strongly encouraged to define these properties in order to allow the warning preference
to work, they are not strictly required and thus should not cause an error in permissive or specification compliance
modes.