### PR TITLE
Use "Arduino Lint" as the project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# arduino-lint
+# Arduino Lint
 
 [![Tests Status](https://github.com/arduino/arduino-lint/workflows/Run%20tests/badge.svg)](https://github.com/arduino/arduino-lint/actions?workflow=Run+tests)
 [![Nightly Status](https://github.com/arduino/arduino-lint/workflows/Nightly%20build/badge.svg)](https://github.com/arduino/arduino-lint/actions?workflow=Nightly+build)
 [![Docs Status](https://github.com/arduino/arduino-lint/workflows/Publish%20documentation/badge.svg)](https://github.com/arduino/arduino-lint/actions?workflow=Publish+documentation)
 
-**arduino-lint** is a command line tool that checks for common problems in [Arduino](https://www.arduino.cc/) projects:
+**Arduino Lint** is a command line tool that checks for common problems in [Arduino](https://www.arduino.cc/) projects:
 
 - Sketches
 - Libraries
@@ -16,7 +16,7 @@ For usage instructions, see [the documentation](https://arduino.github.io/arduin
 
 ## Continuous Integration
 
-There is a GitHub Actions action that makes it easy to use **arduino-lint**` in your CI workflows!
+There is a GitHub Actions action that makes it easy to use **Arduino Lint**` in your CI workflows!
 
 See https://github.com/arduino/arduino-lint-action for more information.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,10 +21,10 @@ There are several ways you can get involved:
 
 ## Issue Reports
 
-Do you need help or have a question about using arduino-lint? Support requests should be made to the
+Do you need help or have a question about using Arduino Lint? Support requests should be made to the
 [Arduino forum](https://forum.arduino.cc/index.php?board=3.0).
 
-High quality bug reports and feature requests are valuable contributions to the arduino-lint project.
+High quality bug reports and feature requests are valuable contributions to the Arduino Lint project.
 
 ### Before reporting an issue
 
@@ -63,7 +63,7 @@ submitting a PR:
 - <a id="breaking"></a> If the PR contains a breaking change, please start the commit message and PR title with the
   string **[breaking]**. Don't forget to describe in the PR description what changes users might need to make in their
   workflow or application due to this PR. A breaking change is a change that forces users to change their command-line
-  invocations or parsing of the JSON formatted output when upgrading from an older version of arduino-lint.
+  invocations or parsing of the JSON formatted output when upgrading from an older version of Arduino Lint.
 - PR titles indirectly become part of the CHANGELOG so it's crucial to provide a good record of **what** change is being
   made in the title; **why** it was made will go in the PR description, along with
   [a link to a GitHub issue](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
@@ -76,7 +76,7 @@ submitting a PR:
 
 ### Development prerequisites
 
-To build arduino-lint from sources you need the following tools to be available in your local environment:
+To build Arduino Lint from sources you need the following tools to be available in your local environment:
 
 - [Go](https://golang.org/doc/install) version 1.14 or later
 - [Taskfile](https://taskfile.dev/#/installation) to help you run the most common tasks from the command line
@@ -123,7 +123,7 @@ To run only the Go unit tests, run:
 task go:test-unit
 ```
 
-By default, all tests for all arduino-lint's Go packages are run. To run unit tests for only one or more specific
+By default, all tests for all Arduino Lint's Go packages are run. To run unit tests for only one or more specific
 packages, you can set the `TARGETS` environment variable, e.g.:
 
 ```
@@ -144,11 +144,11 @@ TEST_REGEX='^TestFindProjects$' TARGETS=./internal/project task go:test-unit
 
 #### Integration tests
 
-Being a command line interface, arduino-lint is heavily interactive and it has to stay consistent in accepting the user
+Being a command line interface, Arduino Lint is heavily interactive and it has to stay consistent in accepting the user
 input and providing the expected output and proper exit codes.
 
 For these reasons, in addition to regular unit tests the project has a suite of integration tests that actually run
-arduino-lint in a different process and assess the options are correctly understood and the output is what we expect.
+`arduino-lint` in a different process and assess the options are correctly understood and the output is what we expect.
 
 ##### Running tests
 
@@ -227,7 +227,7 @@ https://arduino.github.io/arduino-lint/dev/
 #### Local development
 
 The documentation consists of static content written over several Markdown files under the `docs` subfolder of the
-arduino-lint repository, as well as the dynamically generated [command line reference](commands/arduino-lint.md).
+Arduino Lint repository, as well as the dynamically generated [command line reference](commands/arduino-lint.md).
 
 When working on the documentation, it is useful to be able to see the effect the changes will have on the generated
 documentation website. You can build the documentation website and serve it from your personal computer by running the
@@ -269,7 +269,7 @@ Checks are automatically run on every pull request to verify that documentation 
 
 #### Documentation publishing
 
-The arduino-lint git repository has a special branch called `gh-pages` that contains the generated HTML code for the
+The Arduino Lint git repository has a special branch called `gh-pages` that contains the generated HTML code for the
 documentation website. Every time a change is pushed to this special branch, GitHub automatically triggers a deployment
 to pull the change and publish a new version of the website. Do not open Pull Requests to push changes to the `gh-pages`
 branch; that will be done exclusively from the CI.

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,9 +1,9 @@
-# This file is part of arduino-lint.
+# This file is part of Arduino Lint.
 
 # Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 
 # This software is released under the GNU General Public License version 3,
-# which covers the main part of arduino-lint.
+# which covers the main part of Arduino Lint.
 # The terms of this license can be found at:
 # https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -21,37 +21,37 @@ import subprocess
 import click
 from git import Repo
 
-# In order to provide support for multiple arduino-lint releases, Documentation is versioned so that visitors can select
+# In order to provide support for multiple Arduino Lint releases, Documentation is versioned so that visitors can select
 # which version of the documentation website should be displayed. Unfortunately this feature isn't provided by GitHub
 # pages or MkDocs, so we had to implement it on top of the generation process.
 #
 # Before delving into the details of the generation process, here follow some requirements that were established to
 # provide versioned documentation:
 #
-# - A special version of the documentation called `dev` is provided to reflect the status of the arduino-lint on the
+# - A special version of the documentation called `dev` is provided to reflect the status of Arduino Lint on the
 #   `main` branch - this includes unreleased features and bugfixes.
-# - Docs are versioned after the minor version of an arduino-lint release. For example, arduino-lint `0.99.1` and
+# - Docs are versioned after the minor version of an Arduino Lint release. For example, Arduino Lint `0.99.1` and
 #   `0.99.2` will be both covered by documentation version `0.99`.
 # - The landing page of the documentation website will automatically redirect visitors to the documentation of the most
-#   recently released version of arduino-lint.
+#   recently released version of Arduino Lint.
 #
 # To implement the requirements above, the execution of MkDocs is wrapped using a CLI tool called Mike
 # (https://github.com/jimporter/mike) that does a few things for us:
 #
-# - It runs MkDocs targeting subfolders named after the arduino-lint version, e.g. documentation for version `0.10.1`
+# - It runs MkDocs targeting subfolders named after the Arduino Lint version, e.g. documentation for version `0.10.1`
 #   can be found under the folder `0.10`.
 # - It injects an HTML control into the documentation website that lets visitors choose which version of the docs to
 #   browse from a dropdown list.
 # - It provides a redirect to a version we decide when visitors hit the landing page of the documentation website.
 # - It pushes generated contents to the `gh-pages` branch.
 #
-# In order to avoid unwanted changes to the public website hosting the arduino-lint documentation, only Mike is allowed
+# In order to avoid unwanted changes to the public website hosting the Arduino Lint documentation, only Mike is allowed
 # to push changes to the `gh-pages` branch, and this only happens from within the CI, in the "Publish documentation"
 # workflow: https://github.com/arduino/arduino-lint/blob/main/.github/workflows/publish-docs.yml
 #
-# The CI is responsible for guessing which version of arduino-lint we're building docs for, so that generated content
+# The CI is responsible for guessing which version of Arduino Lint we're building docs for, so that generated content
 # will be stored in the appropriate section of the documentation website. Because this guessing might be fairly complex,
-# the logic is implemented in this Python script. The script will determine the version of arduino-lint that was
+# the logic is implemented in this Python script. The script will determine the version of Arduino Lint that was
 # modified in the current commit (either `dev` or an official, numbered release) and whether the redirect to the latest
 # version that happens on the landing page should be updated or not.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-**arduino-lint** is a command line tool that checks for common problems with [Arduino](https://www.arduino.cc/)
+**Arduino Lint** is a command line tool that checks for common problems with [Arduino](https://www.arduino.cc/)
 projects.
 
 Its focus is on the structure, metadata, and configuration of Arduino projects, rather than the code. Rules cover
@@ -18,7 +18,7 @@ arduino-lint
 
 This will automatically detect the project type and check it against the relevant rules.
 
-The default configuration of **arduino-lint** provides for the most common use case, but you have the option of changing
+The default configuration of **Arduino Lint** provides for the most common use case, but you have the option of changing
 settings via [command line flags](commands/arduino-lint.md):
 
 ### Compliance setting
@@ -42,7 +42,7 @@ accepted by this flag are:
 updates of Arduino libraries. In order to be accepted for inclusion in Library Manager, a library is required to meet
 [some requirements](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).
 
-**arduino-lint** provides checks for these requirements as well, controlled by the `--library-manager` flag.
+**Arduino Lint** provides checks for these requirements as well, controlled by the `--library-manager` flag.
 
 The Library Manager submission-specific rules are enabled via `--library-manager submit`. Even if your library isn't yet
 ready to be added to Library Manager, it's a good idea to use this setting to ensure no incompatibilities are
@@ -54,11 +54,11 @@ tell you whether your library is compliant with these rules.
 
 ### Integration
 
-The `--format` flag configures the format of **arduino-lint**'s output. The default `--format text` setting provides
-human readable output. For automation or integration with other tools, the machine readable output provided by
-`--format json` may be more convenient. This setting exposes every detail of the rules that were applied.
+The `--format` flag configures the format of `arduino-lint`'s output. The default `--format text` setting provides human
+readable output. For automation or integration with other tools, the machine readable output provided by `--format json`
+may be more convenient. This setting exposes every detail of the rules that were applied.
 
-The `--report-file` flag causes **arduino-lint** to write the JSON output to the specified file.
+The `--report-file` flag causes `arduino-lint` to write the JSON output to the specified file.
 
 ### Environment variables
 
@@ -72,7 +72,7 @@ Additional configuration options intended for internal use or development can be
 
 ## Continuous integration
 
-**arduino-lint** would be a great addition to your
+**Arduino Lint** would be a great addition to your
 [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) system. Running the tool after each
 change to the project can allow you to identify any problems that were introduced.
 
@@ -81,11 +81,11 @@ This is easily done by using the `arduino/arduino-lint-action`
 https://github.com/arduino/arduino-lint-action
 
 Add [a simple workflow file](https://github.com/arduino/arduino-lint-action#usage) to the repository of your Arduino
-project and GitHub will automatically run arduino-lint on every pull request and push.
+project and GitHub will automatically run Arduino Lint on every pull request and push.
 
 ## Support and feedback
 
-You can discuss or get assistance with using **arduino-lint** on the
+You can discuss or get assistance with using **Arduino Lint** on the
 [Arduino Forum](https://forum.arduino.cc/index.php?board=3.0).
 
 Feedback is welcome! Please submit feature requests or bug reports to the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 The script requires `sh`, which is always available on Linux and macOS. `sh` is not available by default on Windows. The
 script can be run on Windows by installing [Git for Windows](https://gitforwindows.org/), then running it from Git Bash.
 
-This script will install the latest version of arduino-lint to `$PWD/bin`:
+This script will install the latest version of Arduino Lint to `$PWD/bin`:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | sh
@@ -15,10 +15,10 @@ If you want to target a different directory, for example `~/local/bin`, set the 
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | BINDIR=~/local/bin sh
 ```
 
-If you would like to use the `arduino-lint` command from any location, install arduino-lint to a directory already in
-your `PATH` or add the arduino-lint installation path to your `PATH` environment variable.
+If you would like to use the `arduino-lint` command from any location, install Arduino Lint to a directory already in
+your `PATH` or add the Arduino Lint installation path to your `PATH` environment variable.
 
-If you want to download a specific arduino-lint version, for example `0.9.0` or `nightly-latest`, pass the version
+If you want to download a specific Arduino Lint version, for example `0.9.0` or `nightly-latest`, pass the version
 number as a parameter like this:
 
 ```
@@ -30,7 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/insta
 Pre-built binaries for all the supported platforms are available for download from the links below.
 
 If you would like to use the `arduino-lint` command from any location, extract the downloaded file to a directory
-already in your `PATH` or add the arduino-lint installation path to your `PATH` environment variable.
+already in your `PATH` or add the Arduino Lint installation path to your `PATH` environment variable.
 
 #### Latest release
 
@@ -81,5 +81,5 @@ Checksums for the nightly builds are available at
 
 ### Build from source
 
-If you’re familiar with Golang or if you want to contribute to the project, you will probably build arduino-lint locally
+If you’re familiar with Golang or if you want to contribute to the project, you will probably build Arduino Lint locally
 with your Go toolchain. See the ["How to contribute"](CONTRIBUTING.md#building-the-source-code) page for instructions.

--- a/docsgen/main.go
+++ b/docsgen/main.go
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// Package main generates Markdown documentation for the arduino-lint CLI.
+// Package main generates Markdown documentation for the Arduino Lint CLI.
 package main
 
 import (

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -6,10 +6,10 @@
 #
 # Usage:
 #
-# To install the latest version of arduino-lint:
+# To install the latest version of Arduino Lint:
 #    ./install.sh
 #
-# To pin a specific release of arduino-lint:
+# To pin a specific release of Arduino Lint:
 #    ./install.sh 0.9.0
 #
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// Package cli defines the arduino-lint command line interface.
+// Package cli defines the Arduino Lint command line interface.
 package cli
 
 import (
@@ -25,7 +25,7 @@ import (
 func Root() *cobra.Command {
 	rootCommand := &cobra.Command{
 		Short:                 "Linter for Arduino projects.",
-		Long:                  "arduino-lint checks for specification compliance and other common problems with Arduino projects",
+		Long:                  "Arduino Lint checks for specification compliance and other common problems with Arduino projects",
 		DisableFlagsInUseLine: true,
 		Use:                   "arduino-lint [FLAG]... [PROJECT_PATH]...\n\nLint project in PROJECT_PATH or current path if no PROJECT_PATH argument provided.",
 		Run:                   command.ArduinoLint,

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-// Package configuration handles the configuration of the arduino-lint tool.
+// Package configuration handles the configuration of the Arduino Lint tool.
 package configuration
 
 import (
@@ -205,7 +205,7 @@ func Version() string {
 
 var commit string
 
-// Commit returns the HEAD commit of the arduino-lint repository when the application was built.
+// Commit returns the HEAD commit of the Arduino Lint repository when the application was built.
 func Commit() string {
 	return commit
 }

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/defaults.go
+++ b/internal/configuration/defaults.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/rulemode/rulemode.go
+++ b/internal/configuration/rulemode/rulemode.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/rulemode/rulemode_test.go
+++ b/internal/configuration/rulemode/rulemode_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/general/general.go
+++ b/internal/project/general/general.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/general/general_test.go
+++ b/internal/project/general/general_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/library.go
+++ b/internal/project/library/library.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/library_test.go
+++ b/internal/project/library/library_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/libraryproperties/libraryproperties.go
+++ b/internal/project/library/libraryproperties/libraryproperties.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/libraryproperties/librarypropertiesschemas_test.go
+++ b/internal/project/library/libraryproperties/librarypropertiesschemas_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/packageindex/packageindex.go
+++ b/internal/project/packageindex/packageindex.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/packageindex/packageindex_test.go
+++ b/internal/project/packageindex/packageindex_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/boardstxt/boardstxt.go
+++ b/internal/project/platform/boardstxt/boardstxt.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/boardstxt/boardstxt_test.go
+++ b/internal/project/platform/boardstxt/boardstxt_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/boardstxt/boardstxtschema_test.go
+++ b/internal/project/platform/boardstxt/boardstxtschema_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platform.go
+++ b/internal/project/platform/platform.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platform_test.go
+++ b/internal/project/platform/platform_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platformtxt/platformtxt.go
+++ b/internal/project/platform/platformtxt/platformtxt.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platformtxt/platformtxt_test.go
+++ b/internal/project/platform/platformtxt/platformtxt_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platformtxt/platformtxtschema_test.go
+++ b/internal/project/platform/platformtxt/platformtxtschema_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/programmerstxt/programmerstxt.go
+++ b/internal/project/platform/programmerstxt/programmerstxt.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/programmerstxt/programmerstxt_test.go
+++ b/internal/project/platform/programmerstxt/programmerstxt_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/programmerstxt/programmerstxtschema_test.go
+++ b/internal/project/platform/programmerstxt/programmerstxtschema_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/library.go
+++ b/internal/project/projectdata/library.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/packageindex.go
+++ b/internal/project/projectdata/packageindex.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/platform.go
+++ b/internal/project/projectdata/platform.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/platform_test.go
+++ b/internal/project/projectdata/platform_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/projectdata.go
+++ b/internal/project/projectdata/projectdata.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/sketch.go
+++ b/internal/project/projectdata/sketch.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projecttype/projecttype.go
+++ b/internal/project/projecttype/projecttype.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projecttype/projecttype_test.go
+++ b/internal/project/projecttype/projecttype_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/sketch/sketch.go
+++ b/internal/project/sketch/sketch.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/sketch/sketch_test.go
+++ b/internal/project/sketch/sketch_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/feedback/feedback.go
+++ b/internal/result/feedback/feedback.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/outputformat/outputformat.go
+++ b/internal/result/outputformat/outputformat.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/outputformat/outputformat_test.go
+++ b/internal/result/outputformat/outputformat_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/result.go
+++ b/internal/result/result.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
@@ -42,7 +42,7 @@ type Type struct {
 	Summary       summaryReportType           `json:"summary"`
 }
 
-// toolConfigurationReportType is the type for the arduino-lint tool configuration.
+// toolConfigurationReportType is the type for the Arduino Lint tool configuration.
 type toolConfigurationReportType struct {
 	Paths       paths.PathList `json:"paths"`
 	ProjectType string         `json:"projectType"`

--- a/internal/result/result_test.go
+++ b/internal/result/result_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/ruleconfiguration/ruleconfiguration.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/ruleconfiguration/ruleconfiguration_test.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/library.go
+++ b/internal/rule/rulefunction/library.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/library_test.go
+++ b/internal/rule/rulefunction/library_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/packageindex.go
+++ b/internal/rule/rulefunction/packageindex.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/packageindex_test.go
+++ b/internal/rule/rulefunction/packageindex_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/platform.go
+++ b/internal/rule/rulefunction/platform.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/platform_test.go
+++ b/internal/rule/rulefunction/platform_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/rulefunction.go
+++ b/internal/rule/rulefunction/rulefunction.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/rulefunction_test.go
+++ b/internal/rule/rulefunction/rulefunction_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/sketch.go
+++ b/internal/rule/rulefunction/sketch.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/sketch_test.go
+++ b/internal/rule/rulefunction/sketch_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulelevel/rulelevel.go
+++ b/internal/rule/rulelevel/rulelevel.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulelevel/rulelevel_test.go
+++ b/internal/rule/rulelevel/rulelevel_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/ruleresult/ruleresult.go
+++ b/internal/rule/ruleresult/ruleresult.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/compliancelevel/compliancelevel.go
+++ b/internal/rule/schema/compliancelevel/compliancelevel.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/parsevalidationresult.go
+++ b/internal/rule/schema/parsevalidationresult.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/schema.go
+++ b/internal/rule/schema/schema.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/schema_test.go
+++ b/internal/rule/schema/schema_test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/util/test/test.go
+++ b/internal/util/test/test.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
-// This file is part of arduino-lint.
+// This file is part of Arduino Lint.
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
 // This software is released under the GNU General Public License version 3,
-// which covers the main part of arduino-lint.
+// which covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: arduino-lint
+site_name: Arduino Lint
 site_description: Tool to check for problems with Arduino projects
 site_url: https://arduino.github.io/arduino-lint/
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,9 +1,9 @@
-# This file is part of arduino-lint.
+# This file is part of Arduino Lint.
 #
 # Copyright 2020 ARDUINO SA(http: // www.arduino.cc/)
 #
 # This software is released under the GNU General Public License version 3,
-# which covers the main part of arduino-lint.
+# which covers the main part of Arduino Lint.
 # The terms of this license can be found at:
 # https: // www.gnu.org/licenses/gpl-3.0.en.html
 #

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -1,9 +1,9 @@
-# This file is part of arduino-lint.
+# This file is part of Arduino Lint.
 #
 # Copyright 2020 ARDUINO SA(http: // www.arduino.cc/)
 #
 # This software is released under the GNU General Public License version 3,
-# which covers the main part of arduino-lint.
+# which covers the main part of Arduino Lint.
 # The terms of this license can be found at:
 # https: // www.gnu.org/licenses/gpl-3.0.en.html
 #


### PR DESCRIPTION
The tool's command name is `arduino-lint`. Previously, this was also used as the project name but it was decided that
"Arduino Lint" is a better project name. `arduino-lint` should only be used when referring to the command.