### PR TITLE
Always discover subprojects

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -92,22 +92,25 @@ func findProjects(targetPath *paths.Path) ([]Type, error) {
 		return nil, fmt.Errorf("Specified path %s is not an Arduino project", targetPath)
 	}
 
+	var foundParentProjects []Type
 	if configuration.SuperprojectTypeFilter() == projecttype.All || configuration.Recursive() {
 		// Project discovery and/or type detection is required.
-		foundParentProjects := findProjectsUnderPath(targetPath, configuration.SuperprojectTypeFilter(), configuration.Recursive())
-		for _, foundParentProject := range foundParentProjects {
-			foundProjects = append(foundProjects, foundParentProject)
-			foundProjects = append(foundProjects, findSubprojects(foundParentProject, foundParentProject.ProjectType)...)
-		}
+		foundParentProjects = findProjectsUnderPath(targetPath, configuration.SuperprojectTypeFilter(), configuration.Recursive())
 	} else {
 		// Project was explicitly defined by user.
-		foundProjects = append(foundProjects,
+		foundParentProjects = append(foundParentProjects,
 			Type{
 				Path:             targetPath,
 				ProjectType:      configuration.SuperprojectTypeFilter(),
 				SuperprojectType: configuration.SuperprojectTypeFilter(),
 			},
 		)
+	}
+
+	// Discover subprojects of all found projects.
+	for _, foundParentProject := range foundParentProjects {
+		foundProjects = append(foundProjects, foundParentProject)
+		foundProjects = append(foundProjects, findSubprojects(foundParentProject, foundParentProject.ProjectType)...)
 	}
 
 	if foundProjects == nil {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -53,7 +53,7 @@ func FindProjects() ([]Type, error) {
 
 // findProjects handles the recursion for FindProjects().
 func findProjects(targetPath *paths.Path) ([]Type, error) {
-	var foundProjects []Type
+	var foundParentProjects []Type
 
 	// If targetPath is a file, targetPath itself is the project, so it's only necessary to determine/verify the type.
 	if targetPath.IsNotDir() {
@@ -82,39 +82,33 @@ func findProjects(targetPath *paths.Path) ([]Type, error) {
 				ProjectType:      projectType,
 				SuperprojectType: projectType,
 			}
-			foundProjects = append(foundProjects, foundProject)
-
-			foundProjects = append(foundProjects, findSubprojects(foundProject, projectType)...)
-
-			return foundProjects, nil
+			foundParentProjects = append(foundParentProjects, foundProject)
 		}
-
-		return nil, fmt.Errorf("Specified path %s is not an Arduino project", targetPath)
-	}
-
-	var foundParentProjects []Type
-	if configuration.SuperprojectTypeFilter() == projecttype.All || configuration.Recursive() {
-		// Project discovery and/or type detection is required.
-		foundParentProjects = findProjectsUnderPath(targetPath, configuration.SuperprojectTypeFilter(), configuration.Recursive())
 	} else {
-		// Project was explicitly defined by user.
-		foundParentProjects = append(foundParentProjects,
-			Type{
-				Path:             targetPath,
-				ProjectType:      configuration.SuperprojectTypeFilter(),
-				SuperprojectType: configuration.SuperprojectTypeFilter(),
-			},
-		)
+		if configuration.SuperprojectTypeFilter() == projecttype.All || configuration.Recursive() {
+			// Project discovery and/or type detection is required.
+			foundParentProjects = findProjectsUnderPath(targetPath, configuration.SuperprojectTypeFilter(), configuration.Recursive())
+		} else {
+			// Project was explicitly defined by user.
+			foundParentProjects = append(foundParentProjects,
+				Type{
+					Path:             targetPath,
+					ProjectType:      configuration.SuperprojectTypeFilter(),
+					SuperprojectType: configuration.SuperprojectTypeFilter(),
+				},
+			)
+		}
 	}
 
 	// Discover subprojects of all found projects.
+	var foundProjects []Type
 	for _, foundParentProject := range foundParentProjects {
 		foundProjects = append(foundProjects, foundParentProject)
 		foundProjects = append(foundProjects, findSubprojects(foundParentProject, foundParentProject.ProjectType)...)
 	}
 
 	if foundProjects == nil {
-		return nil, fmt.Errorf("No projects found under %s", targetPath)
+		return nil, fmt.Errorf("No projects found with project path %s", targetPath)
 	}
 
 	return foundProjects, nil


### PR DESCRIPTION
The documentation of the `--project-type` flag promises that subprojects will also be discovered:

```
--project-type string      Only lint projects of the specified type and their subprojects. Can be {sketch|library|platform|all}. (default "all")
```

Under a specific combination of configurations a bug caused subprojects to not be discovered:

- `--project-type` flag set to specific project type.
- `--recursive` flag not used.
- `PROJECT_PATH` is a folder (rather than file).

So, for example, given this project structure:
```
FooLibrary
|-- examples
|   `-- FooExample
|       `-- FooExample.ino
|-- src
|   `-- FooLibrary.h
`-- library.properties
```
The following command only linted the library, and not the FooExample sketch:

```
arduino-lint --project-type library FooLibrary
```

Under any other configuration, subprojects were discovered and the FooExample sketch would be linted in the above example.