### PR TITLE
Use major version ref of action in workflow

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -57,7 +57,7 @@ jobs:
       # See: https://github.com/rtCamp/action-slack-notify
       - name: Slack notification of certificate verification failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.1.0
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
@@ -111,7 +111,7 @@ jobs:
       - name: Slack notification of pending certificate expiration
         # Don't send spurious expiration notification if verification fails
         if: failure() && steps.check-expiration.outcome == 'failure'
-        uses: rtCamp/action-slack-notify@v2.1.0
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
           SLACK_MESSAGE: |


### PR DESCRIPTION
At the time the workflow was written the authors of the `rtCamp/action-slack-notify` GitHub Action did not provide a major version ref. This meant that it was necessary to pin the action to a specific version.

Since then, a few new patch releases have been made, meaning an outdated version of the action was in use as a consequence of the pinning. 

The action now offers [a `v2` major ref](https://github.com/rtCamp/action-slack-notify/releases/tag/v2). Use of this ref will cause the workflow to benefit from ongoing development to the action up until such time as a new major release is made, at which time we would need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before updating the major ref (e.g., `v3`).

One of the changes made since the v2.1.0 release that was pinned is the switch from docker.io to ghcr.io as the action's Docker container registry in response to https://github.com/rtCamp/action-slack-notify/issues/52
It's possible this change will help to avoid future spurious workflow failures such as the one experienced in https://github.com/arduino/arduino-lint/actions/runs/714065327