### PR TITLE
Add new mbed architecture variants to rules

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1192,6 +1192,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
+golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180406214816-61147c48b25b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/rule/rulefunction/library.go
+++ b/internal/rule/rulefunction/library.go
@@ -1040,7 +1040,7 @@ func LibraryPropertiesArchitecturesFieldSoloAlias() (result ruleresult.Type, out
 		"espressif32":   {"esp32"},
 		"espressif8266": {"esp8266"},
 		"intel_arc32":   {"arc32"},
-		"nordicnrf52":   {"nRF5", "nrf52", "mbed"},
+		"nordicnrf52":   {"nRF5", "nrf52", "mbed", "mbed_edge", "mbed_nano"},
 	}
 
 	trueArchitecturePresent := func(trueArchitecturesQuery []string) bool {
@@ -1093,6 +1093,10 @@ func LibraryPropertiesArchitecturesFieldValueCase() (result ruleresult.Type, out
 		"i686",
 		"k210",
 		"mbed",
+		"mbed_edge",
+		"mbed_nano",
+		"mbed_portenta",
+		"mbed_rp2040",
 		"megaavr",
 		"mraa",
 		"nRF5",


### PR DESCRIPTION
Rules `LP045` and `LP046` utilize a lists of standardized architecture names. In the recent [2.0.0 release of the Arduino Mbed
OS Boards platform](https://github.com/arduino/ArduinoCore-mbed/releases/tag/2.0.0), the `mbed` architecture was split into four variants:

- `mbed_edge` (Arduino Edge Control)
- `mbed_nano` (Arduino Nano 33 BLE, Arduino RP2040 Connect)
- `mbed_portenta` (Arduino Portenta H7)
- `mbed_rp2040` (Raspberry Pi Pico and other 3rd party RP2040 boards)

So the architecture lists used in the rules should be updated accordingly.