### PR TITLE
Disable LP048 for ARDUINO_LINT_LIBRARY_MANAGER_INDEXING mode

### DIFF
--- a/internal/rule/ruleconfiguration/ruleconfiguration.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration.go
@@ -1010,7 +1010,7 @@ var configurations = []Type{
 		Brief:            "depends not in index",
 		Description:      "This field should be used to define the dependencies available from Library Manager. Library names are case-sensitive.",
 		MessageTemplate:  "library.properties depends field item(s) {{.}} not found in the Library Manager index.",
-		DisableModes:     nil,
+		DisableModes:     []rulemode.Type{rulemode.LibraryManagerIndexing},
 		EnableModes:      []rulemode.Type{rulemode.Default},
 		InfoModes:        nil,
 		WarningModes:     []rulemode.Type{rulemode.Default},

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -97,13 +97,13 @@ def test_library_manager_invalid(run_command):
 
 def test_library_manager_indexing(run_command):
     result = run_command(
-        cmd=[test_data_path.joinpath("library-manager", "Update")],
+        cmd=[test_data_path.joinpath("library-manager", "ARDUINO_LINT_LIBRARY_MANAGER_INDEXING", "Servo")],
         custom_env={"ARDUINO_LINT_LIBRARY_MANAGER_INDEXING": "true"},
     )
     assert result.ok
 
     result = run_command(
-        cmd=[test_data_path.joinpath("library-manager", "Update")],
+        cmd=[test_data_path.joinpath("library-manager", "ARDUINO_LINT_LIBRARY_MANAGER_INDEXING", "Servo")],
         custom_env={"ARDUINO_LINT_LIBRARY_MANAGER_INDEXING": "foo"},
     )
     assert not result.ok

--- a/test/testdata/library-manager/ARDUINO_LINT_LIBRARY_MANAGER_INDEXING/Servo/library.properties
+++ b/test/testdata/library-manager/ARDUINO_LINT_LIBRARY_MANAGER_INDEXING/Servo/library.properties
@@ -1,0 +1,10 @@
+name=Servo
+version=1.1.7
+author=Michael Margolis, Arduino
+maintainer=Arduino <info@arduino.cc>
+sentence=Allows Arduino/Genuino boards to control a variety of servo motors.
+paragraph=This library can control a great number of servos.<br />It makes careful use of timers: the library can control 12 servos using only 1 timer.<br />On the Arduino Due you can control up to 60 servos.<br />
+category=Device Control
+url=http://www.arduino.cc/en/Reference/Servo
+architectures=avr,megaavr,sam,samd,nrf52,stm32f4,mbed
+depends=Arduino_nonexistent


### PR DESCRIPTION
This rule checks for the presence of the library's library.properties `depends` items in the library index. Since the
library index is not available when in `ARDUINO_LINT_LIBRARY_MANAGER_INDEXING` mode, this rule can not run.

Before this change, attempting to lint a library with a library.properties `depends` field when in `ARDUINO_LINT_LIBRARY_MANAGER_INDEXING` mode resulted in a panic:
```
panic: interface conversion: interface {} is nil, not []interface {}

goroutine 1 [running]:
github.com/arduino/arduino-lint/internal/rule/rulefunction.nameInLibraryManagerIndex(0xc000160206, 0x19, 0xddae1d)
        /home/build/internal/rule/rulefunction/library.go:1447 +0x1be
github.com/arduino/arduino-lint/internal/rule/rulefunction.LibraryPropertiesDependsFieldNotInIndex(0xdcd21e, 0x18, 0xc0005a1890)
        /home/build/internal/rule/rulefunction/library.go:1181 +0x224
github.com/arduino/arduino-lint/internal/rule.Runner(0xc0008ea050, 0x1, 0x1)
        /home/build/internal/rule/rule.go:53 +0x2e5
github.com/arduino/arduino-lint/internal/command.ArduinoLint(0xc0000ee580, 0x160b2a0, 0x0, 0x0)
        /home/build/internal/command/command.go:76 +0x219
github.com/spf13/cobra.(*Command).execute(0xc0000ee580, 0xc000088190, 0x0, 0x0, 0xc0000ee580, 0xc000088190)
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:854 +0x2a4
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000ee580, 0x0, 0x0, 0x0)
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
main.main()
        /home/build/main.go:32 +0x32
```