### PR TITLE
Use new arduino/setup-task action name in CI/CD workflows

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/lint-documentation.yml
+++ b/.github/workflows/lint-documentation.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           changelog-file-path: "dist/CHANGELOG.md"
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -24,7 +24,7 @@ jobs:
         run: pip install poetry
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           go-version: "1.14"
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x


### PR DESCRIPTION
The GitHub Actions action for installing [Task](https://taskfile.dev/#/) has graduated from its original home in [the experimental `arduino/action`repository](https://github.com/arduino/actions) with a move to a dedicated permanent repository at [`arduino/setup-task`](https://github.com/arduino/setup-task).

A [1.0.0 release](https://github.com/arduino/setup-task/releases/tag/v1.0.0) has been made and [a `v1` ref](https://github.com/arduino/setup-task/tree/v1) that will track all releases in the major version 1 series. Use of the action's major version ref will cause the workflow to benefit from ongoing development to the action at each [patch or minor release](https://semver.org/) up until such time as a new major release is made. At this time the user will be given the opportunity to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref in the workflows (e.g., `uses: arduino/setup-task@v2`).