### PR TITLE
Avoid hang when linting projects with symlink loops

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -134,7 +134,10 @@ func findProjectsUnderPath(targetPath *paths.Path, projectTypeFilter projecttype
 		return foundProjects
 	}
 
-	if recursive && symlinkDepth < 10 {
+	if recursive {
+		if symlinkDepth > 10 {
+			panic(fmt.Sprintf("symlink depth exceeded maximum while finding projects under %s", targetPath))
+		}
 		// targetPath was not a project, so search the subfolders.
 		directoryListing, _ := targetPath.ReadDir()
 		directoryListing.FilterDirs()

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/arduino/arduino-lint/internal/configuration"
 	"github.com/arduino/arduino-lint/internal/project/projecttype"
@@ -60,28 +59,7 @@ func TestSymlinkLoop(t *testing.T) {
 
 	configuration.Initialize(test.ConfigurationFlags(), []string{libraryPath.String()})
 
-	// The failure condition is FindProjects() never returning, testing for which requires setting up a timeout.
-	done := make(chan bool)
-	go func() {
-		_, err = FindProjects()
-		done <- true
-	}()
-
-	assert.Eventually(
-		t,
-		func() bool {
-			select {
-			case <-done:
-				return true
-			default:
-				return false
-			}
-		},
-		20*time.Second,
-		10*time.Millisecond,
-		"Infinite symlink loop during project discovery",
-	)
-	require.Nil(t, err)
+	assert.Panics(t, func() { FindProjects() }, "Infinite symlink loop encountered during project discovery")
 }
 
 func TestFindProjects(t *testing.T) {


### PR DESCRIPTION
Specific combinations of symlinks can cause infinite recursion loops during project discovery. This can be avoided by
limiting the depth of symlink follows to a reasonable number.

This was implemented in https://github.com/arduino/arduino-lint/commit/ef717d23021545ad74496aa27e0b37ce1ae0eeb1 to make the project discovery code gracefully avoid perpetual recursion in this situation. Unfortunately, it turned out that the project data collection phase that comes after project discovery also suffers from the same problem. Fixing that is more difficult since the incompatible code is in Arduino CLI. So for now the provisional fix is to panic during the project discovery phase, which will at least avoid the far worse behavior of a permanent hang.