### PR TITLE
Generate test build artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ on:
       - "test/**"
       - "Taskfile.yml"
 
+env:
+  BUILDS_ARTIFACT: build-artifacts
+
 jobs:
   test-go:
     strategy:
@@ -82,3 +85,85 @@ jobs:
 
       - name: Run integration tests
         run: task test-integration
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - name: Install Taskfile
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Build
+        run: |
+          PACKAGE_NAME_PREFIX="${{ github.workflow }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
+          fi
+          PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
+          export PACKAGE_NAME_PREFIX
+          task dist:all
+
+      # Transfer builds to artifacts job
+      - name: Upload combined builds artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/
+          name: ${{ env.BUILDS_ARTIFACT }}
+
+  artifacts:
+    name: ${{ matrix.artifact.name }} artifact
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        artifact:
+          - path: "*checksums.txt"
+            name: checksums
+          - path: "*Linux_32bit.tar.gz"
+            name: Linux_X86-32
+          - path: "*Linux_64bit.tar.gz"
+            name: Linux_X86-64
+          - path: "*Linux_ARM64.tar.gz"
+            name: Linux_ARM64
+          - path: "*Linux_ARMv6.tar.gz"
+            name: Linux_ARMv6
+          - path: "*Linux_ARMv7.tar.gz"
+            name: Linux_ARMv7
+          - path: "*macOS_64bit.tar.gz"
+            name: macOS_64
+          - path: "*Windows_32bit.zip"
+            name: Windows_X86-32
+          - path: "*Windows_64bit.zip"
+            name: Windows_X86-64
+
+    steps:
+      - name: Download combined builds artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.BUILDS_ARTIFACT }}
+          path: ${{ env.BUILDS_ARTIFACT }}
+
+      - name: Upload individual build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ env.BUILDS_ARTIFACT }}/${{ matrix.artifact.path }}
+          name: ${{ matrix.artifact.name }}
+
+  clean:
+    needs: artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Remove unneeded combined builds artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ env.BUILDS_ARTIFACT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,6 @@ jobs:
       - name: Check for forgotten code generation
         run: git diff --color --exit-code
 
-      - name: Build
-        run: task build
-
       - name: Run unit tests
         run: task go:test-unit
 


### PR DESCRIPTION
Providing pre-built binaries for every pull request or commit that changes relevant files enables any interested party to
participate in the review or beta testing process without imposing the requirement to set up the build toolchain on their
local machine.

This will also avoid any chance of differences between the tester's environment and the release system environment
introducing spurious results.