### PR TITLE
Use most appropriate function for checking URL

### DIFF
--- a/internal/rule/rulefunction/library.go
+++ b/internal/rule/rulefunction/library.go
@@ -1011,7 +1011,7 @@ func LibraryPropertiesUrlFieldDeadLink() (result ruleresult.Type, output string)
 	}
 
 	logrus.Tracef("Checking URL: %s", url)
-	httpResponse, err := http.Get(url)
+	httpResponse, err := http.Head(url)
 	if err != nil {
 		return ruleresult.Fail, err.Error()
 	}

--- a/internal/rule/rulefunction/library_test.go
+++ b/internal/rule/rulefunction/library_test.go
@@ -751,7 +751,7 @@ func TestLibraryPropertiesUrlFieldDeadLink(t *testing.T) {
 	testTables := []libraryRuleFunctionTestTable{
 		{"Unable to load", "InvalidLibraryProperties", ruleresult.NotRun, ""},
 		{"Not defined", "MissingFields", ruleresult.NotRun, ""},
-		{"Bad URL", "BadURL", ruleresult.Fail, "^Get \"http://invalid/\": dial tcp: lookup invalid:"},
+		{"Bad URL", "BadURL", ruleresult.Fail, "^Head \"http://invalid/\": dial tcp: lookup invalid:"},
 		{"HTTP error 404", "URL404", ruleresult.Fail, "^404 Not Found$"},
 		{"Good URL", "Recursive", ruleresult.Pass, ""},
 	}


### PR DESCRIPTION
From the `http.Get()` documentation:

> Caller should close resp.Body when done reading from it.

This was not done previously. Since the body is not needed, `http.Head()` is more appropriate for this application and it
does not impose the requirement to add additional code to clean up.