### PR TITLE
Allow full JSON pointers in schema validation result parsing functions

### DIFF
--- a/internal/project/packageindex/packageindexschemas_test.go
+++ b/internal/project/packageindex/packageindexschemas_test.go
@@ -157,14 +157,14 @@ func TestMinLength(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("%s less than minimum length of %d (%s)", testTable.propertyPointerString, testTable.minLength, testTable.complianceLevel), func(t *testing.T) {
-			assert.True(t, schema.PropertyLessThanMinLength(strings.TrimPrefix(testTable.propertyPointerString, "/"), packageindex.Validate(packageIndex)[testTable.complianceLevel]))
+			assert.True(t, schema.PropertyLessThanMinLength(testTable.propertyPointerString, packageindex.Validate(packageIndex)[testTable.complianceLevel]))
 		})
 
 		// Test schema validation results with minimum value length.
 		propertyPointer.Set(packageIndex, strings.Repeat("a", testTable.minLength))
 
 		t.Run(fmt.Sprintf("%s at minimum length of %d (%s)", testTable.propertyPointerString, testTable.minLength, testTable.complianceLevel), func(t *testing.T) {
-			assert.False(t, schema.PropertyLessThanMinLength(strings.TrimPrefix(testTable.propertyPointerString, "/"), packageindex.Validate(packageIndex)[testTable.complianceLevel]))
+			assert.False(t, schema.PropertyLessThanMinLength(testTable.propertyPointerString, packageindex.Validate(packageIndex)[testTable.complianceLevel]))
 		})
 	}
 }
@@ -316,7 +316,7 @@ func TestRequired(t *testing.T) {
 
 		validationResult := packageindex.Validate(packageIndex)
 		t.Run(fmt.Sprintf("%s (%s)", testTable.propertyPointerString, testTable.complianceLevel), func(t *testing.T) {
-			testTable.assertion(t, schema.RequiredPropertyMissing(strings.TrimPrefix(testTable.propertyPointerString, "/"), validationResult[testTable.complianceLevel]))
+			testTable.assertion(t, schema.RequiredPropertyMissing(testTable.propertyPointerString, validationResult[testTable.complianceLevel]))
 		})
 	}
 }
@@ -348,7 +348,7 @@ func TestEnum(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("%s: %s (%s)", testTable.propertyPointerString, testTable.propertyValue, testTable.complianceLevel), func(t *testing.T) {
-			testTable.assertion(t, schema.PropertyEnumMismatch(strings.TrimPrefix(testTable.propertyPointerString, "/"), packageindex.Validate(packageIndex)[testTable.complianceLevel]))
+			testTable.assertion(t, schema.PropertyEnumMismatch(testTable.propertyPointerString, packageindex.Validate(packageIndex)[testTable.complianceLevel]))
 		})
 	}
 }
@@ -512,7 +512,7 @@ func TestPattern(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("%s: %s (%s)", testTable.propertyPointerString, testTable.propertyValue, testTable.complianceLevel), func(t *testing.T) {
-			testTable.assertion(t, schema.PropertyPatternMismatch(strings.TrimPrefix(testTable.propertyPointerString, "/"), packageindex.Validate(packageIndex)[testTable.complianceLevel]))
+			testTable.assertion(t, schema.PropertyPatternMismatch(testTable.propertyPointerString, packageindex.Validate(packageIndex)[testTable.complianceLevel]))
 		})
 	}
 }
@@ -567,7 +567,7 @@ func TestType(t *testing.T) {
 			_, err = propertyPointer.Set(packageIndex, testTable.propertyValue)
 
 			t.Run(fmt.Sprintf("%s: %v (%s)", testTable.propertyPointerString, testTable.propertyValue, complianceLevel), func(t *testing.T) {
-				testTable.assertion(t, schema.PropertyTypeMismatch(strings.TrimPrefix(testTable.propertyPointerString, "/"), packageindex.Validate(packageIndex)[complianceLevel]))
+				testTable.assertion(t, schema.PropertyTypeMismatch(testTable.propertyPointerString, packageindex.Validate(packageIndex)[complianceLevel]))
 			})
 		}
 	}
@@ -632,7 +632,7 @@ func TestFormat(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("%s: %s (%s)", testTable.propertyPointerString, testTable.propertyValue, testTable.complianceLevel), func(t *testing.T) {
-			testTable.assertion(t, schema.PropertyFormatMismatch(strings.TrimPrefix(testTable.propertyPointerString, "/"), packageindex.Validate(packageIndex)[testTable.complianceLevel]))
+			testTable.assertion(t, schema.PropertyFormatMismatch(testTable.propertyPointerString, packageindex.Validate(packageIndex)[testTable.complianceLevel]))
 		})
 	}
 }
@@ -693,7 +693,7 @@ func TestAdditionalProperties(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("Additional property in the %s object (%s)", testTable.propertyPointerString, testTable.complianceLevel), func(t *testing.T) {
-			testTable.assertion(t, schema.ProhibitedAdditionalProperties(strings.TrimPrefix(testTable.propertyPointerString, "/"), packageindex.Validate(packageIndex)[testTable.complianceLevel]))
+			testTable.assertion(t, schema.ProhibitedAdditionalProperties(testTable.propertyPointerString, packageindex.Validate(packageIndex)[testTable.complianceLevel]))
 		})
 	}
 }

--- a/internal/rule/schema/parsevalidationresult.go
+++ b/internal/rule/schema/parsevalidationresult.go
@@ -26,42 +26,42 @@ import (
 
 // RequiredPropertyMissing returns whether the given required property is missing from the document.
 func RequiredPropertyMissing(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("#", "/required$", "", "^#/"+propertyName+"$", validationResult)
+	return ValidationErrorMatch("#", "/required$", "", "^#/?"+propertyName+"$", validationResult)
 }
 
 // PropertyPatternMismatch returns whether the given property did not match the regular expression defined in the JSON schema.
 func PropertyPatternMismatch(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("#/"+propertyName, "/pattern$", "", "", validationResult)
+	return ValidationErrorMatch("#/?"+propertyName, "/pattern$", "", "", validationResult)
 }
 
 // PropertyLessThanMinLength returns whether the given property is less than the minimum length allowed by the schema.
 func PropertyLessThanMinLength(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("^#/"+propertyName+"$", "/minLength$", "", "", validationResult)
+	return ValidationErrorMatch("^#/?"+propertyName+"$", "/minLength$", "", "", validationResult)
 }
 
 // PropertyGreaterThanMaxLength returns whether the given property is greater than the maximum length allowed by the schema.
 func PropertyGreaterThanMaxLength(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("^#/"+propertyName+"$", "/maxLength$", "", "", validationResult)
+	return ValidationErrorMatch("^#/?"+propertyName+"$", "/maxLength$", "", "", validationResult)
 }
 
 // PropertyEnumMismatch returns whether the given property does not match any of the items in the enum array.
 func PropertyEnumMismatch(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("#/"+propertyName, "/enum$", "", "", validationResult)
+	return ValidationErrorMatch("#/?"+propertyName, "/enum$", "", "", validationResult)
 }
 
 // PropertyDependenciesMissing returns whether property dependencies of the given property are missing.
 func PropertyDependenciesMissing(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("", "/dependencies/"+propertyName+"/[0-9]+$", "", "", validationResult)
+	return ValidationErrorMatch("", "/dependencies/?"+propertyName+"/[0-9]+$", "", "", validationResult)
 }
 
 // PropertyTypeMismatch returns whether the given property has incorrect type.
 func PropertyTypeMismatch(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("^#/"+propertyName+"$", "/type$", "", "", validationResult)
+	return ValidationErrorMatch("^#/?"+propertyName+"$", "/type$", "", "", validationResult)
 }
 
 // PropertyFormatMismatch returns whether the given property has incorrect format.
 func PropertyFormatMismatch(propertyName string, validationResult ValidationResult) bool {
-	return ValidationErrorMatch("^#/"+propertyName+"$", "/format$", "", "", validationResult)
+	return ValidationErrorMatch("^#/?"+propertyName+"$", "/format$", "", "", validationResult)
 }
 
 // ProhibitedAdditionalProperty returns whether the given property has prohibited additional subproperty(s).

--- a/internal/rule/schema/schema_test.go
+++ b/internal/rule/schema/schema_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/arduino/arduino-lint/internal/project/general"
@@ -228,7 +227,7 @@ func TestProhibitedAdditionalProperties(t *testing.T) {
 		var instance map[string]interface{}
 		json.Unmarshal([]byte(rawInstance), &instance)
 
-		assert.False(t, ProhibitedAdditionalProperties(strings.TrimPrefix(testTable.objectPointerString, "/"), Validate(instance, validSchemaWithReferences)), fmt.Sprintf("No additional properties in %s", testTable.objectPointerString))
+		assert.False(t, ProhibitedAdditionalProperties(testTable.objectPointerString, Validate(instance, validSchemaWithReferences)), fmt.Sprintf("No additional properties in %s", testTable.objectPointerString))
 
 		// Add additional property to object.
 		pointer, err := gojsonpointer.NewJsonPointer(testTable.objectPointerString + "/fooAdditionalProperty")
@@ -237,7 +236,7 @@ func TestProhibitedAdditionalProperties(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("Additional property in the %s object", testTable.objectPointerString), func(t *testing.T) {
-			testTable.assertion(t, ProhibitedAdditionalProperties(strings.TrimPrefix(testTable.objectPointerString, "/"), Validate(instance, validSchemaWithReferences)))
+			testTable.assertion(t, ProhibitedAdditionalProperties(testTable.objectPointerString, Validate(instance, validSchemaWithReferences)))
 		})
 	}
 }


### PR DESCRIPTION
When used with [the "properties" data format](https://pkg.go.dev/github.com/arduino/go-properties-orderedmap#pkg-overview), and most especially with the flat format of the [library.properties](https://arduino.github.io/arduino-cli/dev/library-specification/#libraryproperties-file-format) file that was an initial focus of the project's development, [JSON pointers](https://datatracker.ietf.org/doc/html/rfc6901) are not a terribly intuitive way to refer to a data path.

In this context, it seemed sensible to pre-fill the root prefix on the instance pointer argument of the JSON schema validation result parsing functions. However, now that those functions are being used with the JSON formatted [package index](https://arduino.github.io/arduino-cli/dev/package_index_json-specification/) data file, the requirement to omit this prefix from the JSON pointers is very confusing.

Since the argument is already a regex, it's simple to allow both styles of instance data path references.