### PR TITLE
Various minor improvements to unit tests for package index projects

### DIFF
--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -59,60 +59,60 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			packageIndexPackagesAssertion:     assert.NotNil,
 			packageIndexPackagesDataAssertion: []PackageIndexData{
 				{
-					ID:          "myboard1",
+					ID:          "foopackager1",
 					JSONPointer: "/packages/0",
 				},
 				{
-					ID:          "myboard2",
+					ID:          "foopackager2",
 					JSONPointer: "/packages/1",
 				},
 			},
 			packageIndexPlatformsAssertion: assert.NotNil,
 			packageIndexPlatformsDataAssertion: []PackageIndexData{
 				{
-					ID:          "myboard1:avr@1.0.0",
+					ID:          "foopackager1:avr@1.0.0",
 					JSONPointer: "/packages/0/platforms/0",
 				},
 				{
-					ID:          "myboard1:avr@1.0.1",
+					ID:          "foopackager1:avr@1.0.1",
 					JSONPointer: "/packages/0/platforms/1",
 				},
 				{
-					ID:          "myboard2:samd@2.0.0",
+					ID:          "foopackager2:samd@2.0.0",
 					JSONPointer: "/packages/1/platforms/0",
 				},
 				{
-					ID:          "myboard2:mbed@1.1.1",
+					ID:          "foopackager2:mbed@1.1.1",
 					JSONPointer: "/packages/1/platforms/1",
 				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,
 			packageIndexToolsDataAssertion: []PackageIndexData{
 				{
-					ID:          "myboard2:openocd@0.10.0-arduino1-static",
+					ID:          "foopackager2:openocd@0.10.0-arduino1-static",
 					JSONPointer: "/packages/1/tools/0",
 				},
 				{
-					ID:          "myboard2:CMSIS@4.0.0-atmel",
+					ID:          "foopackager2:CMSIS@4.0.0-atmel",
 					JSONPointer: "/packages/1/tools/1",
 				},
 			},
 			packageIndexSystemsAssertion: assert.NotNil,
 			packageIndexSystemsDataAssertion: []PackageIndexData{
 				{
-					ID:          "myboard2:openocd@0.10.0-arduino1-static - i386-apple-darwin11",
+					ID:          "foopackager2:openocd@0.10.0-arduino1-static - i386-apple-darwin11",
 					JSONPointer: "/packages/1/tools/0/systems/0",
 				},
 				{
-					ID:          "myboard2:openocd@0.10.0-arduino1-static - x86_64-linux-gnu",
+					ID:          "foopackager2:openocd@0.10.0-arduino1-static - x86_64-linux-gnu",
 					JSONPointer: "/packages/1/tools/0/systems/1",
 				},
 				{
-					ID:          "myboard2:CMSIS@4.0.0-atmel - arm-linux-gnueabihf",
+					ID:          "foopackager2:CMSIS@4.0.0-atmel - arm-linux-gnueabihf",
 					JSONPointer: "/packages/1/tools/1/systems/0",
 				},
 				{
-					ID:          "myboard2:CMSIS@4.0.0-atmel - i686-mingw32",
+					ID:          "foopackager2:CMSIS@4.0.0-atmel - i686-mingw32",
 					JSONPointer: "/packages/1/tools/1/systems/1",
 				},
 			},

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -159,32 +159,32 @@ func TestInitializeForPackageIndex(t *testing.T) {
 		testTable.packageIndexPackagesAssertion(t, PackageIndexPackages(), testTable.testName)
 		if PackageIndexPackages() != nil {
 			for index, packageIndexPackage := range PackageIndexPackages() {
-				assert.Equal(t, packageIndexPackage.ID, testTable.packageIndexPackagesDataAssertion[index].ID)
-				assert.Equal(t, packageIndexPackage.JSONPointer, testTable.packageIndexPackagesDataAssertion[index].JSONPointer)
+				assert.Equal(t, packageIndexPackage.ID, testTable.packageIndexPackagesDataAssertion[index].ID, testTable.testName)
+				assert.Equal(t, packageIndexPackage.JSONPointer, testTable.packageIndexPackagesDataAssertion[index].JSONPointer, testTable.testName)
 			}
 		}
 
 		testTable.packageIndexPlatformsAssertion(t, PackageIndexPlatforms(), testTable.testName)
 		if PackageIndexPlatforms() != nil {
 			for index, packageIndexPlatform := range PackageIndexPlatforms() {
-				assert.Equal(t, packageIndexPlatform.ID, testTable.packageIndexPlatformsDataAssertion[index].ID)
-				assert.Equal(t, packageIndexPlatform.JSONPointer, testTable.packageIndexPlatformsDataAssertion[index].JSONPointer)
+				assert.Equal(t, packageIndexPlatform.ID, testTable.packageIndexPlatformsDataAssertion[index].ID, testTable.testName)
+				assert.Equal(t, packageIndexPlatform.JSONPointer, testTable.packageIndexPlatformsDataAssertion[index].JSONPointer, testTable.testName)
 			}
 		}
 
 		testTable.packageIndexToolsAssertion(t, PackageIndexTools(), testTable.testName)
 		if PackageIndexTools() != nil {
 			for index, packageIndexTool := range PackageIndexTools() {
-				assert.Equal(t, packageIndexTool.ID, testTable.packageIndexToolsDataAssertion[index].ID)
-				assert.Equal(t, packageIndexTool.JSONPointer, testTable.packageIndexToolsDataAssertion[index].JSONPointer)
+				assert.Equal(t, packageIndexTool.ID, testTable.packageIndexToolsDataAssertion[index].ID, testTable.testName)
+				assert.Equal(t, packageIndexTool.JSONPointer, testTable.packageIndexToolsDataAssertion[index].JSONPointer, testTable.testName)
 			}
 		}
 
 		testTable.packageIndexSystemsAssertion(t, PackageIndexSystems(), testTable.testName)
 		if PackageIndexSystems() != nil {
 			for index, packageIndexSystem := range PackageIndexSystems() {
-				assert.Equal(t, packageIndexSystem.ID, testTable.packageIndexSystemsDataAssertion[index].ID)
-				assert.Equal(t, packageIndexSystem.JSONPointer, testTable.packageIndexSystemsDataAssertion[index].JSONPointer)
+				assert.Equal(t, packageIndexSystem.ID, testTable.packageIndexSystemsDataAssertion[index].ID, testTable.testName)
+				assert.Equal(t, packageIndexSystem.JSONPointer, testTable.packageIndexSystemsDataAssertion[index].JSONPointer, testTable.testName)
 			}
 		}
 	}

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -159,32 +159,32 @@ func TestInitializeForPackageIndex(t *testing.T) {
 		testTable.packageIndexPackagesAssertion(t, PackageIndexPackages(), testTable.testName)
 		if PackageIndexPackages() != nil {
 			for index, packageIndexPackage := range PackageIndexPackages() {
-				assert.Equal(t, packageIndexPackage.ID, testTable.packageIndexPackagesDataAssertion[index].ID, testTable.testName)
-				assert.Equal(t, packageIndexPackage.JSONPointer, testTable.packageIndexPackagesDataAssertion[index].JSONPointer, testTable.testName)
+				assert.Equal(t, testTable.packageIndexPackagesDataAssertion[index].ID, packageIndexPackage.ID, testTable.testName)
+				assert.Equal(t, testTable.packageIndexPackagesDataAssertion[index].JSONPointer, packageIndexPackage.JSONPointer, testTable.testName)
 			}
 		}
 
 		testTable.packageIndexPlatformsAssertion(t, PackageIndexPlatforms(), testTable.testName)
 		if PackageIndexPlatforms() != nil {
 			for index, packageIndexPlatform := range PackageIndexPlatforms() {
-				assert.Equal(t, packageIndexPlatform.ID, testTable.packageIndexPlatformsDataAssertion[index].ID, testTable.testName)
-				assert.Equal(t, packageIndexPlatform.JSONPointer, testTable.packageIndexPlatformsDataAssertion[index].JSONPointer, testTable.testName)
+				assert.Equal(t, testTable.packageIndexPlatformsDataAssertion[index].ID, packageIndexPlatform.ID, testTable.testName)
+				assert.Equal(t, testTable.packageIndexPlatformsDataAssertion[index].JSONPointer, packageIndexPlatform.JSONPointer, testTable.testName)
 			}
 		}
 
 		testTable.packageIndexToolsAssertion(t, PackageIndexTools(), testTable.testName)
 		if PackageIndexTools() != nil {
 			for index, packageIndexTool := range PackageIndexTools() {
-				assert.Equal(t, packageIndexTool.ID, testTable.packageIndexToolsDataAssertion[index].ID, testTable.testName)
-				assert.Equal(t, packageIndexTool.JSONPointer, testTable.packageIndexToolsDataAssertion[index].JSONPointer, testTable.testName)
+				assert.Equal(t, testTable.packageIndexToolsDataAssertion[index].ID, packageIndexTool.ID, testTable.testName)
+				assert.Equal(t, testTable.packageIndexToolsDataAssertion[index].JSONPointer, packageIndexTool.JSONPointer, testTable.testName)
 			}
 		}
 
 		testTable.packageIndexSystemsAssertion(t, PackageIndexSystems(), testTable.testName)
 		if PackageIndexSystems() != nil {
 			for index, packageIndexSystem := range PackageIndexSystems() {
-				assert.Equal(t, packageIndexSystem.ID, testTable.packageIndexSystemsDataAssertion[index].ID, testTable.testName)
-				assert.Equal(t, packageIndexSystem.JSONPointer, testTable.packageIndexSystemsDataAssertion[index].JSONPointer, testTable.testName)
+				assert.Equal(t, testTable.packageIndexSystemsDataAssertion[index].ID, packageIndexSystem.ID, testTable.testName)
+				assert.Equal(t, testTable.packageIndexSystemsDataAssertion[index].JSONPointer, packageIndexSystem.JSONPointer, testTable.testName)
 			}
 		}
 	}

--- a/internal/project/projectdata/testdata/packageindexes/valid-package-index/package_foo_index.json
+++ b/internal/project/projectdata/testdata/packageindexes/valid-package-index/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard1",
+      "name": "foopackager1",
       "maintainer": "Jane Developer",
       "websiteURL": "https://github.com/janedeveloper/myboard",
       "email": "jane@example.com",
@@ -65,7 +65,7 @@
       "tools": []
     },
     {
-      "name": "myboard2",
+      "name": "foopackager2",
       "maintainer": "Jane Developer",
       "websiteURL": "https://github.com/janedeveloper/myboard",
       "email": "jane@example.com",

--- a/internal/rule/rulefunction/packageindex_test.go
+++ b/internal/rule/rulefunction/packageindex_test.go
@@ -114,8 +114,8 @@ func TestPackageIndexFormat(t *testing.T) {
 func TestPackageIndexPackagesWebsiteURLDeadLink(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Dead URLs", "packages-websiteurl-dead", ruleresult.Fail, "^myboard1, myboard2$"},
-		{"Invalid URL", "packages-websiteurl-invalid", ruleresult.Fail, "^myboard$"},
+		{"Dead URLs", "packages-websiteurl-dead", ruleresult.Fail, "^foopackager1, foopackager2$"},
+		{"Invalid URL", "packages-websiteurl-invalid", ruleresult.Fail, "^foopackager$"},
 		{"Valid URL", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -125,7 +125,7 @@ func TestPackageIndexPackagesWebsiteURLDeadLink(t *testing.T) {
 func TestPackageIndexPackagesHelpOnlineDeadLink(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Dead URLs", "packages-help-online-dead", ruleresult.Fail, "^myboard1, myboard2$"},
+		{"Dead URLs", "packages-help-online-dead", ruleresult.Fail, "^foopackager1, foopackager2$"},
 		{"Valid URL", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -135,7 +135,7 @@ func TestPackageIndexPackagesHelpOnlineDeadLink(t *testing.T) {
 func TestPackageIndexPackagesPlatformsHelpOnlineDeadLink(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Dead URLs", "packages-platforms-help-online-dead", ruleresult.Fail, "^myboard:avr@1\\.0\\.0, myboard:samd@1\\.0\\.0$"},
+		{"Dead URLs", "packages-platforms-help-online-dead", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0, foopackager:samd@1\\.0\\.0$"},
 		{"Valid URL", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -145,7 +145,7 @@ func TestPackageIndexPackagesPlatformsHelpOnlineDeadLink(t *testing.T) {
 func TestPackageIndexPackagesPlatformsURLDeadLink(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Dead URLs", "packages-platforms-url-dead", ruleresult.Fail, "^myboard:avr@1\\.0\\.0, myboard:samd@1\\.0\\.0$"},
+		{"Dead URLs", "packages-platforms-url-dead", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0, foopackager:samd@1\\.0\\.0$"},
 		{"Valid URL", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -155,7 +155,7 @@ func TestPackageIndexPackagesPlatformsURLDeadLink(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsURLDeadLink(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Dead URLs", "packages-tools-systems-url-dead", ruleresult.Fail, "^myboard:CMSIS@4\\.0\\.0-atmel - arm-linux-gnueabihf, myboard:CMSIS@4\\.0\\.0-atmel - i686-mingw32$"},
+		{"Dead URLs", "packages-tools-systems-url-dead", ruleresult.Fail, "^foopackager:CMSIS@4\\.0\\.0-atmel - arm-linux-gnueabihf, foopackager:CMSIS@4\\.0\\.0-atmel - i686-mingw32$"},
 		{"Valid URL", "valid-package-index", ruleresult.Pass, ""},
 	}
 

--- a/internal/rule/rulefunction/testdata/packageindexes/packages-help-online-dead/package_foo_index.json
+++ b/internal/rule/rulefunction/testdata/packageindexes/packages-help-online-dead/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard1",
+      "name": "foopackager1",
       "maintainer": "Jane Developer",
       "websiteURL": "http://example.com",
       "email": "jane@example.com",
@@ -12,7 +12,7 @@
       "tools": []
     },
     {
-      "name": "myboard2",
+      "name": "foopackager2",
       "maintainer": "Jane Developer",
       "websiteURL": "http://example.com",
       "email": "jane@example.com",

--- a/internal/rule/rulefunction/testdata/packageindexes/packages-platforms-help-online-dead/package_foo_index.json
+++ b/internal/rule/rulefunction/testdata/packageindexes/packages-platforms-help-online-dead/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard",
+      "name": "foopackager",
       "maintainer": "Jane Developer",
       "websiteURL": "http://example.com",
       "email": "jane@example.com",

--- a/internal/rule/rulefunction/testdata/packageindexes/packages-platforms-url-dead/package_foo_index.json
+++ b/internal/rule/rulefunction/testdata/packageindexes/packages-platforms-url-dead/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard",
+      "name": "foopackager",
       "maintainer": "Jane Developer",
       "websiteURL": "http://example.com",
       "email": "jane@example.com",

--- a/internal/rule/rulefunction/testdata/packageindexes/packages-tools-systems-url-dead/package_foo_index.json
+++ b/internal/rule/rulefunction/testdata/packageindexes/packages-tools-systems-url-dead/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard",
+      "name": "foopackager",
       "maintainer": "Jane Developer",
       "websiteURL": "http://httpstat.us/404",
       "email": "jane@example.com",

--- a/internal/rule/rulefunction/testdata/packageindexes/packages-websiteurl-dead/package_foo_index.json
+++ b/internal/rule/rulefunction/testdata/packageindexes/packages-websiteurl-dead/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard1",
+      "name": "foopackager1",
       "maintainer": "Jane Developer",
       "websiteURL": "http://httpstat.us/403",
       "email": "jane@example.com",
@@ -12,7 +12,7 @@
       "tools": []
     },
     {
-      "name": "myboard2",
+      "name": "foopackager2",
       "maintainer": "Jane Developer",
       "websiteURL": "http://httpstat.us/404",
       "email": "jane@example.com",

--- a/internal/rule/rulefunction/testdata/packageindexes/packages-websiteurl-invalid/package_foo_index.json
+++ b/internal/rule/rulefunction/testdata/packageindexes/packages-websiteurl-invalid/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard",
+      "name": "foopackager",
       "maintainer": "Jane Developer",
       "websiteURL": "invalid",
       "email": "jane@example.com",

--- a/internal/rule/rulefunction/testdata/packageindexes/valid-package-index/package_foo_index.json
+++ b/internal/rule/rulefunction/testdata/packageindexes/valid-package-index/package_foo_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard",
+      "name": "foopackager",
       "maintainer": "Jane Developer",
       "websiteURL": "http://example.com",
       "email": "jane@example.com",

--- a/test/testdata/project-type/PackageIndex/package_valid_index.json
+++ b/test/testdata/project-type/PackageIndex/package_valid_index.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "name": "myboard",
+      "name": "foopackager",
       "maintainer": "Jane Developer",
       "websiteURL": "http://example.com",
       "email": "jane@example.com",


### PR DESCRIPTION
- Use more appropriate packager name in test data package indexes
- Add test messages to all package index project data tests
- Correct order of arguments in test equality assertions