### PR TITLE
Provide schema validation results in package index project data

### DIFF
--- a/internal/project/projectdata/packageindex.go
+++ b/internal/project/projectdata/packageindex.go
@@ -21,6 +21,8 @@ import (
 
 	clipackageindex "github.com/arduino/arduino-cli/arduino/cores/packageindex"
 	"github.com/arduino/arduino-lint/internal/project/packageindex"
+	"github.com/arduino/arduino-lint/internal/rule/schema"
+	"github.com/arduino/arduino-lint/internal/rule/schema/compliancelevel"
 )
 
 // PackageIndexData is the type for package index data.
@@ -41,6 +43,7 @@ func InitializeForPackageIndex() {
 	packageIndexPlatforms = nil
 	packageIndexTools = nil
 	packageIndexSystems = nil
+	packageIndexSchemaValidationResult = nil
 	if packageIndexLoadError == nil {
 		packageIndexPackages = getPackageIndexData(PackageIndex(), "", "packages", "", "name", "")
 
@@ -55,6 +58,8 @@ func InitializeForPackageIndex() {
 		for _, toolData := range PackageIndexTools() {
 			packageIndexSystems = append(packageIndexSystems, getPackageIndexData(toolData.Object, toolData.JSONPointer, "systems", toolData.ID+" - ", "host", "")...)
 		}
+
+		packageIndexSchemaValidationResult = packageindex.Validate(PackageIndex())
 	}
 }
 
@@ -105,6 +110,13 @@ var packageIndexSystems []PackageIndexData
 // PackageIndexSystems returns the slice of system data for the package index.
 func PackageIndexSystems() []PackageIndexData {
 	return packageIndexSystems
+}
+
+var packageIndexSchemaValidationResult map[compliancelevel.Type]schema.ValidationResult
+
+// PackageIndexSchemaValidationResult returns the result of validating the package index against the JSON schema.
+func PackageIndexSchemaValidationResult() map[compliancelevel.Type]schema.ValidationResult {
+	return packageIndexSchemaValidationResult
 }
 
 func getPackageIndexData(interfaceObject map[string]interface{}, pointerPrefix string, dataKey string, iDPrefix string, iDKey string, versionKey string) []PackageIndexData {

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -36,19 +36,20 @@ func init() {
 
 func TestInitializeForPackageIndex(t *testing.T) {
 	testTables := []struct {
-		testName                           string
-		path                               *paths.Path
-		packageIndexAssertion              assert.ValueAssertionFunc
-		packageIndexLoadErrorAssertion     assert.ValueAssertionFunc
-		packageIndexCLILoadErrorAssertion  assert.ValueAssertionFunc
-		packageIndexPackagesAssertion      assert.ValueAssertionFunc
-		packageIndexPackagesDataAssertion  []PackageIndexData
-		packageIndexPlatformsAssertion     assert.ValueAssertionFunc
-		packageIndexPlatformsDataAssertion []PackageIndexData
-		packageIndexToolsAssertion         assert.ValueAssertionFunc
-		packageIndexToolsDataAssertion     []PackageIndexData
-		packageIndexSystemsAssertion       assert.ValueAssertionFunc
-		packageIndexSystemsDataAssertion   []PackageIndexData
+		testName                                    string
+		path                                        *paths.Path
+		packageIndexAssertion                       assert.ValueAssertionFunc
+		packageIndexLoadErrorAssertion              assert.ValueAssertionFunc
+		packageIndexCLILoadErrorAssertion           assert.ValueAssertionFunc
+		packageIndexPackagesAssertion               assert.ValueAssertionFunc
+		packageIndexPackagesDataAssertion           []PackageIndexData
+		packageIndexPlatformsAssertion              assert.ValueAssertionFunc
+		packageIndexPlatformsDataAssertion          []PackageIndexData
+		packageIndexToolsAssertion                  assert.ValueAssertionFunc
+		packageIndexToolsDataAssertion              []PackageIndexData
+		packageIndexSystemsAssertion                assert.ValueAssertionFunc
+		packageIndexSystemsDataAssertion            []PackageIndexData
+		packageIndexSchemaValidationResultAssertion assert.ValueAssertionFunc
 	}{
 		{
 			testName:                          "Valid",
@@ -116,6 +117,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/tools/1/systems/1",
 				},
 			},
+			packageIndexSchemaValidationResultAssertion: assert.NotNil,
 		},
 		{
 			testName:                          "Missing IDs",
@@ -191,6 +193,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/tools/2/systems/0",
 				},
 			},
+			packageIndexSchemaValidationResultAssertion: assert.NotNil,
 		},
 		{
 			testName:                          "Empty IDs",
@@ -266,28 +269,31 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/tools/2/systems/0",
 				},
 			},
+			packageIndexSchemaValidationResultAssertion: assert.NotNil,
 		},
 		{
-			testName:                          "Invalid package index",
-			path:                              packageIndexTestDataPath.Join("invalid-package-index", "package_foo_index.json"),
-			packageIndexAssertion:             assert.Nil,
-			packageIndexLoadErrorAssertion:    assert.NotNil,
-			packageIndexCLILoadErrorAssertion: assert.NotNil,
-			packageIndexPackagesAssertion:     assert.Nil,
-			packageIndexPlatformsAssertion:    assert.Nil,
-			packageIndexToolsAssertion:        assert.Nil,
-			packageIndexSystemsAssertion:      assert.Nil,
+			testName:                                    "Invalid package index",
+			path:                                        packageIndexTestDataPath.Join("invalid-package-index", "package_foo_index.json"),
+			packageIndexAssertion:                       assert.Nil,
+			packageIndexLoadErrorAssertion:              assert.NotNil,
+			packageIndexCLILoadErrorAssertion:           assert.NotNil,
+			packageIndexPackagesAssertion:               assert.Nil,
+			packageIndexPlatformsAssertion:              assert.Nil,
+			packageIndexToolsAssertion:                  assert.Nil,
+			packageIndexSystemsAssertion:                assert.Nil,
+			packageIndexSchemaValidationResultAssertion: assert.Nil,
 		},
 		{
-			testName:                          "Invalid JSON",
-			path:                              packageIndexTestDataPath.Join("invalid-JSON", "package_foo_index.json"),
-			packageIndexAssertion:             assert.Nil,
-			packageIndexLoadErrorAssertion:    assert.NotNil,
-			packageIndexCLILoadErrorAssertion: assert.NotNil,
-			packageIndexPackagesAssertion:     assert.Nil,
-			packageIndexPlatformsAssertion:    assert.Nil,
-			packageIndexToolsAssertion:        assert.Nil,
-			packageIndexSystemsAssertion:      assert.Nil,
+			testName:                                    "Invalid JSON",
+			path:                                        packageIndexTestDataPath.Join("invalid-JSON", "package_foo_index.json"),
+			packageIndexAssertion:                       assert.Nil,
+			packageIndexLoadErrorAssertion:              assert.NotNil,
+			packageIndexCLILoadErrorAssertion:           assert.NotNil,
+			packageIndexPackagesAssertion:               assert.Nil,
+			packageIndexPlatformsAssertion:              assert.Nil,
+			packageIndexToolsAssertion:                  assert.Nil,
+			packageIndexSystemsAssertion:                assert.Nil,
+			packageIndexSchemaValidationResultAssertion: assert.Nil,
 		},
 	}
 


### PR DESCRIPTION
This allows the package index to be validated against its JSON schemas only once per project, with those results shared
between all the schema-based rules.