### PR TITLE
Provide object-level packages[].platforms[].boards[] package index da…

### DIFF
--- a/internal/project/projectdata/packageindex.go
+++ b/internal/project/projectdata/packageindex.go
@@ -41,6 +41,7 @@ func InitializeForPackageIndex() {
 
 	packageIndexPackages = nil
 	packageIndexPlatforms = nil
+	packageIndexBoards = nil
 	packageIndexTools = nil
 	packageIndexSystems = nil
 	packageIndexSchemaValidationResult = nil
@@ -49,6 +50,10 @@ func InitializeForPackageIndex() {
 
 		for _, packageData := range PackageIndexPackages() {
 			packageIndexPlatforms = append(packageIndexPlatforms, getPackageIndexData(packageData.Object, packageData.JSONPointer, "platforms", packageData.ID+":", "architecture", "version")...)
+		}
+
+		for _, platformData := range PackageIndexPlatforms() {
+			packageIndexBoards = append(packageIndexBoards, getPackageIndexData(platformData.Object, platformData.JSONPointer, "boards", platformData.ID+" - ", "name", "")...)
 		}
 
 		for _, packageData := range PackageIndexPackages() {
@@ -96,6 +101,13 @@ var packageIndexPlatforms []PackageIndexData
 // PackageIndexPlatforms returns the slice of platform data for the package index.
 func PackageIndexPlatforms() []PackageIndexData {
 	return packageIndexPlatforms
+}
+
+var packageIndexBoards []PackageIndexData
+
+// PackageIndexBoards returns the slice of board data for the package index.
+func PackageIndexBoards() []PackageIndexData {
+	return packageIndexBoards
 }
 
 var packageIndexTools []PackageIndexData

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -45,6 +45,8 @@ func TestInitializeForPackageIndex(t *testing.T) {
 		packageIndexPackagesDataAssertion           []PackageIndexData
 		packageIndexPlatformsAssertion              assert.ValueAssertionFunc
 		packageIndexPlatformsDataAssertion          []PackageIndexData
+		packageIndexBoardsAssertion                 assert.ValueAssertionFunc
+		packageIndexBoardsDataAssertion             []PackageIndexData
 		packageIndexToolsAssertion                  assert.ValueAssertionFunc
 		packageIndexToolsDataAssertion              []PackageIndexData
 		packageIndexSystemsAssertion                assert.ValueAssertionFunc
@@ -85,6 +87,41 @@ func TestInitializeForPackageIndex(t *testing.T) {
 				{
 					ID:          "foopackager2:mbed@1.1.1",
 					JSONPointer: "/packages/1/platforms/1",
+				},
+			},
+			packageIndexBoardsAssertion: assert.NotNil,
+			packageIndexBoardsDataAssertion: []PackageIndexData{
+				{
+					ID:          "foopackager1:avr@1.0.0 - My Board",
+					JSONPointer: "/packages/0/platforms/0/boards/0",
+				},
+				{
+					ID:          "foopackager1:avr@1.0.0 - My Board Pro",
+					JSONPointer: "/packages/0/platforms/0/boards/1",
+				},
+				{
+					ID:          "foopackager1:avr@1.0.1 - My Board",
+					JSONPointer: "/packages/0/platforms/1/boards/0",
+				},
+				{
+					ID:          "foopackager1:avr@1.0.1 - My Board Pro",
+					JSONPointer: "/packages/0/platforms/1/boards/1",
+				},
+				{
+					ID:          "foopackager2:samd@2.0.0 - My Board",
+					JSONPointer: "/packages/1/platforms/0/boards/0",
+				},
+				{
+					ID:          "foopackager2:samd@2.0.0 - My Board Pro",
+					JSONPointer: "/packages/1/platforms/0/boards/1",
+				},
+				{
+					ID:          "foopackager2:mbed@1.1.1 - My Board",
+					JSONPointer: "/packages/1/platforms/1/boards/0",
+				},
+				{
+					ID:          "foopackager2:mbed@1.1.1 - My Board Pro",
+					JSONPointer: "/packages/1/platforms/1/boards/1",
 				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,
@@ -153,6 +190,53 @@ func TestInitializeForPackageIndex(t *testing.T) {
 				{
 					ID:          "/packages/1/platforms/1",
 					JSONPointer: "/packages/1/platforms/1",
+				},
+				{
+					ID:          "foopackager2:megaavr@1.0.0",
+					JSONPointer: "/packages/1/platforms/2",
+				},
+			},
+			packageIndexBoardsAssertion: assert.NotNil,
+			packageIndexBoardsDataAssertion: []PackageIndexData{
+				{
+					ID:          "/packages/0/platforms/0/boards/0",
+					JSONPointer: "/packages/0/platforms/0/boards/0",
+				},
+				{
+					ID:          "/packages/0/platforms/0/boards/1",
+					JSONPointer: "/packages/0/platforms/0/boards/1",
+				},
+				{
+					ID:          "/packages/0/platforms/1/boards/0",
+					JSONPointer: "/packages/0/platforms/1/boards/0",
+				},
+				{
+					ID:          "/packages/0/platforms/1/boards/1",
+					JSONPointer: "/packages/0/platforms/1/boards/1",
+				},
+				{
+					ID:          "/packages/1/platforms/0/boards/0",
+					JSONPointer: "/packages/1/platforms/0/boards/0",
+				},
+				{
+					ID:          "/packages/1/platforms/0/boards/1",
+					JSONPointer: "/packages/1/platforms/0/boards/1",
+				},
+				{
+					ID:          "/packages/1/platforms/1/boards/0",
+					JSONPointer: "/packages/1/platforms/1/boards/0",
+				},
+				{
+					ID:          "/packages/1/platforms/1/boards/1",
+					JSONPointer: "/packages/1/platforms/1/boards/1",
+				},
+				{
+					ID:          "/packages/1/platforms/2/boards/0",
+					JSONPointer: "/packages/1/platforms/2/boards/0",
+				},
+				{
+					ID:          "foopackager2:megaavr@1.0.0 - My Board Pro",
+					JSONPointer: "/packages/1/platforms/2/boards/1",
 				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,
@@ -230,6 +314,53 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					ID:          "/packages/1/platforms/1",
 					JSONPointer: "/packages/1/platforms/1",
 				},
+				{
+					ID:          "foopackager2:megaavr@1.0.0",
+					JSONPointer: "/packages/1/platforms/2",
+				},
+			},
+			packageIndexBoardsAssertion: assert.NotNil,
+			packageIndexBoardsDataAssertion: []PackageIndexData{
+				{
+					ID:          "/packages/0/platforms/0/boards/0",
+					JSONPointer: "/packages/0/platforms/0/boards/0",
+				},
+				{
+					ID:          "/packages/0/platforms/0/boards/1",
+					JSONPointer: "/packages/0/platforms/0/boards/1",
+				},
+				{
+					ID:          "/packages/0/platforms/1/boards/0",
+					JSONPointer: "/packages/0/platforms/1/boards/0",
+				},
+				{
+					ID:          "/packages/0/platforms/1/boards/1",
+					JSONPointer: "/packages/0/platforms/1/boards/1",
+				},
+				{
+					ID:          "/packages/1/platforms/0/boards/0",
+					JSONPointer: "/packages/1/platforms/0/boards/0",
+				},
+				{
+					ID:          "/packages/1/platforms/0/boards/1",
+					JSONPointer: "/packages/1/platforms/0/boards/1",
+				},
+				{
+					ID:          "/packages/1/platforms/1/boards/0",
+					JSONPointer: "/packages/1/platforms/1/boards/0",
+				},
+				{
+					ID:          "/packages/1/platforms/1/boards/1",
+					JSONPointer: "/packages/1/platforms/1/boards/1",
+				},
+				{
+					ID:          "/packages/1/platforms/2/boards/0",
+					JSONPointer: "/packages/1/platforms/2/boards/0",
+				},
+				{
+					ID:          "foopackager2:megaavr@1.0.0 - My Board Pro",
+					JSONPointer: "/packages/1/platforms/2/boards/1",
+				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,
 			packageIndexToolsDataAssertion: []PackageIndexData{
@@ -279,6 +410,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			packageIndexCLILoadErrorAssertion:           assert.NotNil,
 			packageIndexPackagesAssertion:               assert.Nil,
 			packageIndexPlatformsAssertion:              assert.Nil,
+			packageIndexBoardsAssertion:                 assert.Nil,
 			packageIndexToolsAssertion:                  assert.Nil,
 			packageIndexSystemsAssertion:                assert.Nil,
 			packageIndexSchemaValidationResultAssertion: assert.Nil,
@@ -291,6 +423,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			packageIndexCLILoadErrorAssertion:           assert.NotNil,
 			packageIndexPackagesAssertion:               assert.Nil,
 			packageIndexPlatformsAssertion:              assert.Nil,
+			packageIndexBoardsAssertion:                 assert.Nil,
 			packageIndexToolsAssertion:                  assert.Nil,
 			packageIndexSystemsAssertion:                assert.Nil,
 			packageIndexSchemaValidationResultAssertion: assert.Nil,
@@ -325,6 +458,14 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			for index, packageIndexPlatform := range PackageIndexPlatforms() {
 				assert.Equal(t, testTable.packageIndexPlatformsDataAssertion[index].ID, packageIndexPlatform.ID, testTable.testName)
 				assert.Equal(t, testTable.packageIndexPlatformsDataAssertion[index].JSONPointer, packageIndexPlatform.JSONPointer, testTable.testName)
+			}
+		}
+
+		testTable.packageIndexBoardsAssertion(t, PackageIndexBoards(), testTable.testName)
+		if PackageIndexBoards() != nil {
+			for index, packageIndexBoard := range PackageIndexBoards() {
+				assert.Equal(t, testTable.packageIndexBoardsDataAssertion[index].ID, packageIndexBoard.ID, testTable.testName)
+				assert.Equal(t, testTable.packageIndexBoardsDataAssertion[index].JSONPointer, packageIndexBoard.JSONPointer, testTable.testName)
 			}
 		}
 

--- a/internal/project/projectdata/testdata/packageindexes/empty-ids/package_foo_index.json
+++ b/internal/project/projectdata/testdata/packageindexes/empty-ids/package_foo_index.json
@@ -124,6 +124,32 @@
               "version": "6.0.1-arduino5"
             }
           ]
+        },
+        {
+          "name": "My Board",
+          "architecture": "megaavr",
+          "version": "1.0.0",
+          "category": "Contributed",
+          "help": {
+            "online": "http://example.com/forum/myboard"
+          },
+          "url": "https://janedeveloper.github.io/myboard/myboard-1.0.1.zip",
+          "archiveFileName": "myboard-1.0.1.zip",
+          "checksum": "SHA-256:9c86ee28a7ce9fe33e8b07ec643316131e0031b0d22e63bb398902a5fdadbca9",
+          "size": "15125",
+          "boards": [{ "name": "" }, { "name": "My Board Pro" }],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
         }
       ],
       "tools": [

--- a/internal/project/projectdata/testdata/packageindexes/missing-ids/package_foo_index.json
+++ b/internal/project/projectdata/testdata/packageindexes/missing-ids/package_foo_index.json
@@ -121,6 +121,32 @@
               "version": "6.0.1-arduino5"
             }
           ]
+        },
+        {
+          "name": "My Board",
+          "architecture": "megaavr",
+          "version": "1.0.0",
+          "category": "Contributed",
+          "help": {
+            "online": "http://example.com/forum/myboard"
+          },
+          "url": "https://janedeveloper.github.io/myboard/myboard-1.0.1.zip",
+          "archiveFileName": "myboard-1.0.1.zip",
+          "checksum": "SHA-256:9c86ee28a7ce9fe33e8b07ec643316131e0031b0d22e63bb398902a5fdadbca9",
+          "size": "15125",
+          "boards": [{ "foo": "My Board" }, { "name": "My Board Pro" }],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
         }
       ],
       "tools": [


### PR DESCRIPTION
…ta to rules

Data checking rules for package indexes need to iterate over its object-level components. To facilitate this, slices of
such objects accompanied by the necessary metadata are generated as package index project data.

This was already done for packages, platforms, and tools, but not for boards. Although board objects are trivial, this
seems like it will provide for cleaner rule functions that apply to to these objects than the alternative of generating
the data on a per-rule basis.