### PR TITLE
Correct package index schema's regex for size property

### DIFF
--- a/etc/schemas/arduino-package-index-definitions-schema.json
+++ b/etc/schemas/arduino-package-index-definitions-schema.json
@@ -770,7 +770,7 @@
         "base": {
           "object": {
             "type": "string",
-            "pattern": "[0-9]+"
+            "pattern": "^[0-9]+$"
           }
         },
         "permissive": {

--- a/internal/project/packageindex/packageindexschemas_test.go
+++ b/internal/project/packageindex/packageindexschemas_test.go
@@ -412,9 +412,9 @@ func TestPattern(t *testing.T) {
 		{"/packages/0/platforms/0/size", "42", compliancelevel.Specification, assert.False},
 		{"/packages/0/platforms/0/size", "42", compliancelevel.Strict, assert.False},
 
-		{"/packages/0/platforms/0/size", "foo", compliancelevel.Permissive, assert.True},
-		{"/packages/0/platforms/0/size", "foo", compliancelevel.Specification, assert.True},
-		{"/packages/0/platforms/0/size", "foo", compliancelevel.Strict, assert.True},
+		{"/packages/0/platforms/0/size", "42B", compliancelevel.Permissive, assert.True},
+		{"/packages/0/platforms/0/size", "42B", compliancelevel.Specification, assert.True},
+		{"/packages/0/platforms/0/size", "42B", compliancelevel.Strict, assert.True},
 
 		{"/packages/0/tools/0/systems/0/archiveFileName", "foo.tar.bz2", compliancelevel.Permissive, assert.False},
 		{"/packages/0/tools/0/systems/0/archiveFileName", "foo.tar.bz2", compliancelevel.Specification, assert.False},

--- a/internal/rule/schema/schemadata/bindata.go
+++ b/internal/rule/schema/schemadata/bindata.go
@@ -3306,7 +3306,7 @@ var _arduinoPackageIndexDefinitionsSchemaJson = []byte(`{
         "base": {
           "object": {
             "type": "string",
-            "pattern": "[0-9]+"
+            "pattern": "^[0-9]+$"
           }
         },
         "permissive": {


### PR DESCRIPTION
The `packages[].platforms[].size` and `packages[].tools[].systems[].size` properties are string representations of
integers, and thus must consist solely of the characters 0-9. The previous regular expression for a valid size value only
required that a number be found somewhere in the string.