### PR TITLE
Provide object-level `packages[].platforms[].toolsDependencies[]` package index data to rules

### DIFF
--- a/internal/project/projectdata/packageindex.go
+++ b/internal/project/projectdata/packageindex.go
@@ -43,6 +43,7 @@ func InitializeForPackageIndex() {
 	packageIndexPackages = nil
 	packageIndexPlatforms = nil
 	packageIndexBoards = nil
+	packageIndexToolsDependencies = nil
 	packageIndexTools = nil
 	packageIndexSystems = nil
 	packageIndexSchemaValidationResult = nil
@@ -55,6 +56,10 @@ func InitializeForPackageIndex() {
 
 		for _, platformData := range PackageIndexPlatforms() {
 			packageIndexBoards = append(packageIndexBoards, getPackageIndexData(platformData.Object, platformData.JSONPointer, "boards", platformData.ID, " - {{index . 0}}", []string{"name"})...)
+		}
+
+		for _, platformData := range PackageIndexPlatforms() {
+			packageIndexToolsDependencies = append(packageIndexToolsDependencies, getPackageIndexData(platformData.Object, platformData.JSONPointer, "toolsDependencies", platformData.ID, " - {{index . 0}}:{{index . 1}}@{{index . 2}}", []string{"packager", "name", "version"})...)
 		}
 
 		for _, packageData := range PackageIndexPackages() {
@@ -109,6 +114,13 @@ var packageIndexBoards []PackageIndexData
 // PackageIndexBoards returns the slice of board data for the package index.
 func PackageIndexBoards() []PackageIndexData {
 	return packageIndexBoards
+}
+
+var packageIndexToolsDependencies []PackageIndexData
+
+// PackageIndexToolsDependencies returns the slice of tool dependency data for the package index.
+func PackageIndexToolsDependencies() []PackageIndexData {
+	return packageIndexToolsDependencies
 }
 
 var packageIndexTools []PackageIndexData

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -47,6 +47,8 @@ func TestInitializeForPackageIndex(t *testing.T) {
 		packageIndexPlatformsDataAssertion          []PackageIndexData
 		packageIndexBoardsAssertion                 assert.ValueAssertionFunc
 		packageIndexBoardsDataAssertion             []PackageIndexData
+		packageIndexToolsDependenciesAssertion      assert.ValueAssertionFunc
+		packageIndexToolsDependenciesDataAssertion  []PackageIndexData
 		packageIndexToolsAssertion                  assert.ValueAssertionFunc
 		packageIndexToolsDataAssertion              []PackageIndexData
 		packageIndexSystemsAssertion                assert.ValueAssertionFunc
@@ -122,6 +124,41 @@ func TestInitializeForPackageIndex(t *testing.T) {
 				{
 					ID:          "foopackager2:mbed@1.1.1 - My Board Pro",
 					JSONPointer: "/packages/1/platforms/1/boards/1",
+				},
+			},
+			packageIndexToolsDependenciesAssertion: assert.NotNil,
+			packageIndexToolsDependenciesDataAssertion: []PackageIndexData{
+				{
+					ID:          "foopackager1:avr@1.0.0 - arduino:avr-gcc@4.8.1-arduino5",
+					JSONPointer: "/packages/0/platforms/0/toolsDependencies/0",
+				},
+				{
+					ID:          "foopackager1:avr@1.0.0 - arduino:avrdude@6.0.1-arduino5",
+					JSONPointer: "/packages/0/platforms/0/toolsDependencies/1",
+				},
+				{
+					ID:          "foopackager1:avr@1.0.1 - arduino:avr-gcc@7.3.0-atmel3.6.1-arduino7",
+					JSONPointer: "/packages/0/platforms/1/toolsDependencies/0",
+				},
+				{
+					ID:          "foopackager1:avr@1.0.1 - arduino:avrdude@6.3.0-arduino17",
+					JSONPointer: "/packages/0/platforms/1/toolsDependencies/1",
+				},
+				{
+					ID:          "foopackager2:samd@2.0.0 - arduino:arm-none-eabi-gcc@7-2017q4",
+					JSONPointer: "/packages/1/platforms/0/toolsDependencies/0",
+				},
+				{
+					ID:          "foopackager2:samd@2.0.0 - arduino:bossac@1.7.0-arduino3",
+					JSONPointer: "/packages/1/platforms/0/toolsDependencies/1",
+				},
+				{
+					ID:          "foopackager2:mbed@1.1.1 - arduino:openocd@0.11.0-arduino2",
+					JSONPointer: "/packages/1/platforms/1/toolsDependencies/0",
+				},
+				{
+					ID:          "foopackager2:mbed@1.1.1 - arduino:arm-none-eabi-gcc@7-2017q4",
+					JSONPointer: "/packages/1/platforms/1/toolsDependencies/1",
 				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,
@@ -237,6 +274,57 @@ func TestInitializeForPackageIndex(t *testing.T) {
 				{
 					ID:          "foopackager2:megaavr@1.0.0 - My Board Pro",
 					JSONPointer: "/packages/1/platforms/2/boards/1",
+				},
+			},
+			packageIndexToolsDependenciesAssertion: assert.NotNil,
+			packageIndexToolsDependenciesDataAssertion: []PackageIndexData{
+				{
+					ID:          "/packages/0/platforms/0/toolsDependencies/0",
+					JSONPointer: "/packages/0/platforms/0/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/0/platforms/0/toolsDependencies/1",
+					JSONPointer: "/packages/0/platforms/0/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/0/platforms/1/toolsDependencies/0",
+					JSONPointer: "/packages/0/platforms/1/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/0/platforms/1/toolsDependencies/1",
+					JSONPointer: "/packages/0/platforms/1/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/0/toolsDependencies/0",
+					JSONPointer: "/packages/1/platforms/0/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/1/platforms/0/toolsDependencies/1",
+					JSONPointer: "/packages/1/platforms/0/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/1/toolsDependencies/0",
+					JSONPointer: "/packages/1/platforms/1/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/1/platforms/1/toolsDependencies/1",
+					JSONPointer: "/packages/1/platforms/1/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/2/toolsDependencies/0",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/1/platforms/2/toolsDependencies/1",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/2/toolsDependencies/2",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/2",
+				},
+				{
+					ID:          "foopackager2:megaavr@1.0.0 - arduino:CMSIS@4.5.0",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/3",
 				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,
@@ -362,6 +450,57 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/platforms/2/boards/1",
 				},
 			},
+			packageIndexToolsDependenciesAssertion: assert.NotNil,
+			packageIndexToolsDependenciesDataAssertion: []PackageIndexData{
+				{
+					ID:          "/packages/0/platforms/0/toolsDependencies/0",
+					JSONPointer: "/packages/0/platforms/0/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/0/platforms/0/toolsDependencies/1",
+					JSONPointer: "/packages/0/platforms/0/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/0/platforms/1/toolsDependencies/0",
+					JSONPointer: "/packages/0/platforms/1/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/0/platforms/1/toolsDependencies/1",
+					JSONPointer: "/packages/0/platforms/1/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/0/toolsDependencies/0",
+					JSONPointer: "/packages/1/platforms/0/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/1/platforms/0/toolsDependencies/1",
+					JSONPointer: "/packages/1/platforms/0/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/1/toolsDependencies/0",
+					JSONPointer: "/packages/1/platforms/1/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/1/platforms/1/toolsDependencies/1",
+					JSONPointer: "/packages/1/platforms/1/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/2/toolsDependencies/0",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/0",
+				},
+				{
+					ID:          "/packages/1/platforms/2/toolsDependencies/1",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/1",
+				},
+				{
+					ID:          "/packages/1/platforms/2/toolsDependencies/2",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/2",
+				},
+				{
+					ID:          "foopackager2:megaavr@1.0.0 - arduino:CMSIS@4.5.0",
+					JSONPointer: "/packages/1/platforms/2/toolsDependencies/3",
+				},
+			},
 			packageIndexToolsAssertion: assert.NotNil,
 			packageIndexToolsDataAssertion: []PackageIndexData{
 				{
@@ -411,6 +550,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			packageIndexPackagesAssertion:               assert.Nil,
 			packageIndexPlatformsAssertion:              assert.Nil,
 			packageIndexBoardsAssertion:                 assert.Nil,
+			packageIndexToolsDependenciesAssertion:      assert.Nil,
 			packageIndexToolsAssertion:                  assert.Nil,
 			packageIndexSystemsAssertion:                assert.Nil,
 			packageIndexSchemaValidationResultAssertion: assert.Nil,
@@ -424,6 +564,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			packageIndexPackagesAssertion:               assert.Nil,
 			packageIndexPlatformsAssertion:              assert.Nil,
 			packageIndexBoardsAssertion:                 assert.Nil,
+			packageIndexToolsDependenciesAssertion:      assert.Nil,
 			packageIndexToolsAssertion:                  assert.Nil,
 			packageIndexSystemsAssertion:                assert.Nil,
 			packageIndexSchemaValidationResultAssertion: assert.Nil,
@@ -466,6 +607,14 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			for index, packageIndexBoard := range PackageIndexBoards() {
 				assert.Equal(t, testTable.packageIndexBoardsDataAssertion[index].ID, packageIndexBoard.ID, testTable.testName)
 				assert.Equal(t, testTable.packageIndexBoardsDataAssertion[index].JSONPointer, packageIndexBoard.JSONPointer, testTable.testName)
+			}
+		}
+
+		testTable.packageIndexToolsDependenciesAssertion(t, PackageIndexToolsDependencies(), testTable.testName)
+		if PackageIndexToolsDependencies() != nil {
+			for index, packageIndexToolsDependency := range PackageIndexToolsDependencies() {
+				assert.Equal(t, testTable.packageIndexToolsDependenciesDataAssertion[index].ID, packageIndexToolsDependency.ID, testTable.testName)
+				assert.Equal(t, testTable.packageIndexToolsDependenciesDataAssertion[index].JSONPointer, packageIndexToolsDependency.JSONPointer, testTable.testName)
 			}
 		}
 

--- a/internal/project/projectdata/testdata/packageindexes/empty-ids/package_foo_index.json
+++ b/internal/project/projectdata/testdata/packageindexes/empty-ids/package_foo_index.json
@@ -52,12 +52,12 @@
             {
               "packager": "arduino",
               "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "version": "7.3.0-atmel3.6.1-arduino7"
             },
             {
               "packager": "arduino",
               "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "version": "6.3.0-arduino17"
             }
           ]
         }
@@ -89,13 +89,13 @@
           "toolsDependencies": [
             {
               "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "name": "bossac",
+              "version": "1.7.0-arduino3"
             }
           ]
         },
@@ -115,13 +115,13 @@
           "toolsDependencies": [
             {
               "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "name": "openocd",
+              "version": "0.11.0-arduino2"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
             }
           ]
         },
@@ -140,14 +140,24 @@
           "boards": [{ "name": "" }, { "name": "My Board Pro" }],
           "toolsDependencies": [
             {
-              "packager": "arduino",
+              "packager": "",
               "name": "avr-gcc",
               "version": "4.8.1-arduino5"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
+              "name": "",
               "version": "6.0.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd",
+              "version": ""
+            },
+            {
+              "packager": "arduino",
+              "name": "CMSIS",
+              "version": "4.5.0"
             }
           ]
         }

--- a/internal/project/projectdata/testdata/packageindexes/missing-ids/package_foo_index.json
+++ b/internal/project/projectdata/testdata/packageindexes/missing-ids/package_foo_index.json
@@ -51,12 +51,12 @@
             {
               "packager": "arduino",
               "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "version": "7.3.0-atmel3.6.1-arduino7"
             },
             {
               "packager": "arduino",
               "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "version": "6.3.0-arduino17"
             }
           ]
         }
@@ -87,13 +87,13 @@
           "toolsDependencies": [
             {
               "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "name": "bossac",
+              "version": "1.7.0-arduino3"
             }
           ]
         },
@@ -112,13 +112,13 @@
           "toolsDependencies": [
             {
               "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "name": "openocd",
+              "version": "0.11.0-arduino2"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
             }
           ]
         },
@@ -137,14 +137,21 @@
           "boards": [{ "foo": "My Board" }, { "name": "My Board Pro" }],
           "toolsDependencies": [
             {
-              "packager": "arduino",
               "name": "avr-gcc",
               "version": "4.8.1-arduino5"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
               "version": "6.0.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd"
+            },
+            {
+              "packager": "arduino",
+              "name": "CMSIS",
+              "version": "4.5.0"
             }
           ]
         }

--- a/internal/project/projectdata/testdata/packageindexes/valid-package-index/package_foo_index.json
+++ b/internal/project/projectdata/testdata/packageindexes/valid-package-index/package_foo_index.json
@@ -52,12 +52,12 @@
             {
               "packager": "arduino",
               "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "version": "7.3.0-atmel3.6.1-arduino7"
             },
             {
               "packager": "arduino",
               "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "version": "6.3.0-arduino17"
             }
           ]
         }
@@ -89,13 +89,13 @@
           "toolsDependencies": [
             {
               "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "name": "bossac",
+              "version": "1.7.0-arduino3"
             }
           ]
         },
@@ -115,13 +115,13 @@
           "toolsDependencies": [
             {
               "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "name": "openocd",
+              "version": "0.11.0-arduino2"
             },
             {
               "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
             }
           ]
         }


### PR DESCRIPTION
Data checking rules for package indexes need to iterate over its object-level components. To facilitate this, slices of
such objects accompanied by the necessary metadata are generated as package index project data.

This was already done for packages, platforms, boards, and tools, but not for tools dependencies.