### PR TITLE
Make symlink prohibition rule catch links with folder target

### DIFF
--- a/internal/rule/rulefunction/library.go
+++ b/internal/rule/rulefunction/library.go
@@ -88,7 +88,6 @@ func LibraryContainsSymlinks() (result ruleresult.Type, output string) {
 	if err != nil {
 		panic(err)
 	}
-	projectPathListing.FilterOutDirs()
 
 	symlinkPaths := []string{}
 	for _, projectPathItem := range projectPathListing {

--- a/internal/rule/rulefunction/library_test.go
+++ b/internal/rule/rulefunction/library_test.go
@@ -105,6 +105,7 @@ func TestLibraryHasSubmodule(t *testing.T) {
 
 func TestLibraryContainsSymlinks(t *testing.T) {
 	testLibrary := "Recursive"
+	// Set up a library with a file target symlink.
 	symlinkPath := librariesTestDataPath.Join(testLibrary, "test-symlink")
 	// It's probably most friendly to developers using Windows to create the symlink needed for the test on demand.
 	err := os.Symlink(librariesTestDataPath.Join(testLibrary, "library.properties").String(), symlinkPath.String())
@@ -112,7 +113,20 @@ func TestLibraryContainsSymlinks(t *testing.T) {
 	defer symlinkPath.RemoveAll() // clean up
 
 	testTables := []libraryRuleFunctionTestTable{
-		{"Has symlink", testLibrary, ruleresult.Fail, ""},
+		{"Has file target symlink", testLibrary, ruleresult.Fail, ""},
+	}
+
+	checkLibraryRuleFunction(LibraryContainsSymlinks, testTables, t)
+
+	err = symlinkPath.RemoveAll()
+	require.Nil(t, err)
+
+	// Set up a library with a folder target symlink.
+	err = os.Symlink(librariesTestDataPath.Join(testLibrary, "src").String(), symlinkPath.String())
+	require.Nil(t, err)
+
+	testTables = []libraryRuleFunctionTestTable{
+		{"Has folder target symlink", testLibrary, ruleresult.Fail, ""},
 	}
 
 	checkLibraryRuleFunction(LibraryContainsSymlinks, testTables, t)


### PR DESCRIPTION
The use of [`FilterOutDirs()`](https://pkg.go.dev/github.com/arduino/go-paths-helper#PathList.FilterOutDirs) on the path list removed symlinks with folder targets, causing rule LS005 to only detect symlinks with file targets. But all types of symlinks are prohibited so this resulted in false negatives.

As reported at https://github.com/arduino/arduino-lint/pull/56#issuecomment-880569913