### PR TITLE
Simplify summary output

### DIFF
--- a/internal/result/result.go
+++ b/internal/result/result.go
@@ -194,8 +194,15 @@ func (results Type) ProjectSummaryText(lintedProject project.Type) string {
 		panic(fmt.Sprintf("Unable to find report for %v when generating report summary text", lintedProject.Path))
 	}
 
-	projectSummaryReport := results.Projects[projectReportIndex].Summary
-	return fmt.Sprintf("Finished linting project. Results:\nWarning count: %v\nError count: %v\nRules passed: %v", projectSummaryReport.WarningCount, projectSummaryReport.ErrorCount, projectSummaryReport.Pass)
+	projectSummaryReport := "Linter results for project: "
+	projectSummaryData := results.Projects[projectReportIndex].Summary
+	if projectSummaryData.ErrorCount == 0 && projectSummaryData.WarningCount == 0 {
+		projectSummaryReport += "no errors or warnings"
+	} else {
+		projectSummaryReport += fmt.Sprintf("%v ERRORS, %v WARNINGS", projectSummaryData.ErrorCount, projectSummaryData.WarningCount)
+	}
+
+	return projectSummaryReport
 }
 
 // AddSummary summarizes the rule results for all projects and adds it to the report.
@@ -220,7 +227,14 @@ func (results *Type) AddSummary() {
 
 // SummaryText returns a text summary of the cumulative rule results.
 func (results Type) SummaryText() string {
-	return fmt.Sprintf("Finished linting projects. Results:\nWarning count: %v\nError count: %v\nRules passed: %v", results.Summary.WarningCount, results.Summary.ErrorCount, results.Summary.Pass)
+	summaryReport := "Linter results for projects: "
+	if results.Summary.ErrorCount == 0 && results.Summary.WarningCount == 0 {
+		summaryReport += "no errors or warnings"
+	} else {
+		summaryReport += fmt.Sprintf("%v ERRORS, %v WARNINGS", results.Summary.ErrorCount, results.Summary.WarningCount)
+	}
+
+	return summaryReport
 }
 
 // JSONReport returns a JSON formatted report of rules on all projects in string encoding.

--- a/internal/result/result_test.go
+++ b/internal/result/result_test.go
@@ -207,7 +207,11 @@ func TestAddProjectSummary(t *testing.T) {
 		assert.Equal(t, testTable.expectedPass, results.Projects[0].Summary.Pass)
 		assert.Equal(t, testTable.expectedWarningCount, results.Projects[0].Summary.WarningCount)
 		assert.Equal(t, testTable.expectedErrorCount, results.Projects[0].Summary.ErrorCount)
-		assert.Equal(t, fmt.Sprintf("Finished linting project. Results:\nWarning count: %v\nError count: %v\nRules passed: %v", testTable.expectedWarningCount, testTable.expectedErrorCount, testTable.expectedPass), results.ProjectSummaryText(lintedProject))
+		if testTable.expectedErrorCount == 0 && testTable.expectedWarningCount == 0 {
+			assert.Equal(t, "Linter results for project: no errors or warnings", results.ProjectSummaryText(lintedProject))
+		} else {
+			assert.Equal(t, fmt.Sprintf("Linter results for project: %v ERRORS, %v WARNINGS", testTable.expectedErrorCount, testTable.expectedWarningCount), results.ProjectSummaryText(lintedProject))
+		}
 	}
 }
 
@@ -290,7 +294,11 @@ func TestAddSummary(t *testing.T) {
 		assert.Equal(t, testTable.expectedPass, results.Passed())
 		assert.Equal(t, testTable.expectedWarningCount, results.Summary.WarningCount)
 		assert.Equal(t, testTable.expectedErrorCount, results.Summary.ErrorCount)
-		assert.Equal(t, fmt.Sprintf("Finished linting projects. Results:\nWarning count: %v\nError count: %v\nRules passed: %v", testTable.expectedWarningCount, testTable.expectedErrorCount, testTable.expectedPass), results.SummaryText())
+		if testTable.expectedErrorCount == 0 && testTable.expectedWarningCount == 0 {
+			assert.Equal(t, "Linter results for projects: no errors or warnings", results.SummaryText())
+		} else {
+			assert.Equal(t, fmt.Sprintf("Linter results for projects: %v ERRORS, %v WARNINGS", testTable.expectedErrorCount, testTable.expectedWarningCount), results.SummaryText())
+		}
 	}
 }
 


### PR DESCRIPTION
This less verbose approach to the project and projects linting summary output provides the same amount of information in
a more approachable format.

Before:
```
Linting library in E:\SomeLibrary
Rule LP017 result: fail
ERROR: Library name Servo is in use by a library in the Library Manager index. Each library must have a unique name value. If your library is already in the index, use the "--library-manager update" flag.
Rule LD002 result: fail
WARNING: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Finished linting project. Results:
Warning count: 1
Error count: 1
Rules passed: false

-------------------

Linting sketch in E:\SomeLibrary\examples\Knob

Finished linting project. Results:
Warning count: 0
Error count: 0
Rules passed: true

-------------------

Finished linting projects. Results:
Warning count: 1
Error count: 1
Rules passed: false
```
After:
```
Linting library in E:\SomeLibrary
Rule LP017 result: fail
ERROR: Library name Servo is in use by a library in the Library Manager index. Each library must have a unique name value. If your library is already in the index, use the "--library-manager update" flag.
Rule LD002 result: fail
WARNING: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license

Linter results for project: 1 ERRORS, 1 WARNINGS

-------------------

Linting sketch in E:\SomeLibrary\examples\Knob

Linter results for project: no errors or warnings

-------------------

Linter results for projects: 1 ERRORS, 1 WARNINGS
```
