### PR TITLE
Format output text for rule results to improve readability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mitchellh/mapstructure v1.4.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/ory/go-acc v0.2.6 // indirect
 	github.com/ory/herodot v0.9.1 // indirect
 	github.com/ory/jsonschema/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -813,6 +813,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/oleiade/reflections v1.0.0/go.mod h1:RbATFBbKYkVdqmSFtx13Bb/tVhR0lgOBXunWTZKeL4w=
 github.com/oleksandr/bonjour v0.0.0-20160508152359-5dcf00d8b228 h1:Cvfd2dOlXIPTeEkOT/h8PyK4phBngOM4at9/jlgy7d4=
 github.com/oleksandr/bonjour v0.0.0-20160508152359-5dcf00d8b228/go.mod h1:MGuVJ1+5TX1SCoO2Sx0eAnjpdRytYla2uC1YIZfkC9c=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/internal/result/result_test.go
+++ b/internal/result/result_test.go
@@ -77,7 +77,8 @@ func TestRecord(t *testing.T) {
 	flags.Set("verbose", "true")
 	require.Nil(t, configuration.Initialize(flags, projectPaths))
 	summaryText := results.Record(lintedProject, ruleConfiguration, ruleresult.Fail, ruleOutput)
-	assert.Equal(t, fmt.Sprintf("Rule %s result: %s\n%s: %s\n", ruleConfiguration.ID, ruleresult.Fail, rulelevel.Error, message(ruleConfiguration.MessageTemplate, ruleOutput)), summaryText)
+	outputAssertion := "Rule LS001 result: fail\nERROR: Path does not contain a valid Arduino library. See:                                                              \n       https://arduino.github.io/arduino-cli/latest/library-specification                                               \n"
+	assert.Equal(t, outputAssertion, summaryText)
 	summaryText = results.Record(lintedProject, ruleConfiguration, ruleresult.NotRun, ruleOutput)
 	assert.Equal(t, fmt.Sprintf("Rule %s result: %s\n%s: %s\n", ruleConfiguration.ID, ruleresult.NotRun, rulelevel.Notice, ruleOutput), summaryText, "Non-fail result should not use message")
 	summaryText = results.Record(lintedProject, ruleConfiguration, ruleresult.Pass, "")
@@ -85,7 +86,8 @@ func TestRecord(t *testing.T) {
 	flags.Set("verbose", "false")
 	require.Nil(t, configuration.Initialize(flags, projectPaths))
 	summaryText = results.Record(lintedProject, ruleConfiguration, ruleresult.Fail, ruleOutput)
-	assert.Equal(t, fmt.Sprintf("%s: %s (Rule %s)\n", rulelevel.Error, message(ruleConfiguration.MessageTemplate, ruleOutput), ruleConfiguration.ID), summaryText)
+	outputAssertion = "ERROR: Path does not contain a valid Arduino library. See:                                                              \n       https://arduino.github.io/arduino-cli/latest/library-specification (Rule LS001)                                  \n"
+	assert.Equal(t, outputAssertion, summaryText)
 	summaryText = results.Record(lintedProject, ruleConfiguration, ruleresult.NotRun, ruleOutput)
 	assert.Equal(t, "", summaryText, "Non-fail result should not result in output in non-verbose mode")
 	summaryText = results.Record(lintedProject, ruleConfiguration, ruleresult.Pass, "")


### PR DESCRIPTION
Previously, the output text for the rule results had no formatting to speak of. It was simply a single, often long, line of text. Wrapping of this text was at the mercy of whatever displayed it. When there were multiple rule results in the output it melded into a wall of dense text.

The readability is improved by two formatting changes:

- Format the rule level (e.g., ERROR, WARNING) text and the rule message text into separate columns
- Wrap the rule message text, maintaining the column alignment after line breaks

This is accomplished by using [`github.com/olekukonko/tablewriter`](https://pkg.go.dev/github.com/olekukonko/tablewriter) to put the result output for each rule is made into a single row, borderless table.

Example output from before this change:
```
ERROR: Library name Servo is in use by a library in the Library Manager index. Each library must have a unique name value. If your library is already in the index, use the "--library-manager update" flag. (Rule LP017)
WARNING: No license file found. See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license (Rule LD002)
```
after:
```
ERROR: Library name Servo is in use by a library in the Library Manager index. Each library must have a unique name
       value. If your library is already in the index, use the "--library-manager update" flag. (Rule LP017)
WARNING: No license file found. See:
         https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license
         (Rule LD002)
```