### PR TITLE
Use ">>" in place of "-" between package index ID components

### DIFF
--- a/internal/project/projectdata/packageindex.go
+++ b/internal/project/projectdata/packageindex.go
@@ -56,15 +56,15 @@ func InitializeForPackageIndex() {
 		}
 
 		for _, platformData := range PackageIndexPlatforms() {
-			packageIndexBoards = append(packageIndexBoards, getPackageIndexData(platformData.Object, platformData.JSONPointer, "boards", platformData.ID, " - {{index . 0}}", []string{"name"})...)
+			packageIndexBoards = append(packageIndexBoards, getPackageIndexData(platformData.Object, platformData.JSONPointer, "boards", platformData.ID, " >> {{index . 0}}", []string{"name"})...)
 		}
 
 		for _, platformData := range PackageIndexPlatforms() {
-			packageIndexToolsDependencies = append(packageIndexToolsDependencies, getPackageIndexData(platformData.Object, platformData.JSONPointer, "toolsDependencies", platformData.ID, " - {{index . 0}}:{{index . 1}}@{{index . 2}}", []string{"packager", "name", "version"})...)
+			packageIndexToolsDependencies = append(packageIndexToolsDependencies, getPackageIndexData(platformData.Object, platformData.JSONPointer, "toolsDependencies", platformData.ID, " >> {{index . 0}}:{{index . 1}}@{{index . 2}}", []string{"packager", "name", "version"})...)
 		}
 
 		for _, platformData := range PackageIndexPlatforms() {
-			packageIndexDiscoveryDependencies = append(packageIndexDiscoveryDependencies, getPackageIndexData(platformData.Object, platformData.JSONPointer, "discoveryDependencies", platformData.ID, " - {{index . 0}}:{{index . 1}}", []string{"packager", "name"})...)
+			packageIndexDiscoveryDependencies = append(packageIndexDiscoveryDependencies, getPackageIndexData(platformData.Object, platformData.JSONPointer, "discoveryDependencies", platformData.ID, " >> {{index . 0}}:{{index . 1}}", []string{"packager", "name"})...)
 		}
 
 		for _, packageData := range PackageIndexPackages() {
@@ -72,7 +72,7 @@ func InitializeForPackageIndex() {
 		}
 
 		for _, toolData := range PackageIndexTools() {
-			packageIndexSystems = append(packageIndexSystems, getPackageIndexData(toolData.Object, toolData.JSONPointer, "systems", toolData.ID, " - {{index . 0}}", []string{"host"})...)
+			packageIndexSystems = append(packageIndexSystems, getPackageIndexData(toolData.Object, toolData.JSONPointer, "systems", toolData.ID, " >> {{index . 0}}", []string{"host"})...)
 		}
 
 		packageIndexSchemaValidationResult = packageindex.Validate(PackageIndex())

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -96,93 +96,93 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			packageIndexBoardsAssertion: assert.NotNil,
 			packageIndexBoardsDataAssertion: []PackageIndexData{
 				{
-					ID:          "foopackager1:avr@1.0.0 - My Board",
+					ID:          "foopackager1:avr@1.0.0 >> My Board",
 					JSONPointer: "/packages/0/platforms/0/boards/0",
 				},
 				{
-					ID:          "foopackager1:avr@1.0.0 - My Board Pro",
+					ID:          "foopackager1:avr@1.0.0 >> My Board Pro",
 					JSONPointer: "/packages/0/platforms/0/boards/1",
 				},
 				{
-					ID:          "foopackager1:avr@1.0.1 - My Board",
+					ID:          "foopackager1:avr@1.0.1 >> My Board",
 					JSONPointer: "/packages/0/platforms/1/boards/0",
 				},
 				{
-					ID:          "foopackager1:avr@1.0.1 - My Board Pro",
+					ID:          "foopackager1:avr@1.0.1 >> My Board Pro",
 					JSONPointer: "/packages/0/platforms/1/boards/1",
 				},
 				{
-					ID:          "foopackager2:samd@2.0.0 - My Board",
+					ID:          "foopackager2:samd@2.0.0 >> My Board",
 					JSONPointer: "/packages/1/platforms/0/boards/0",
 				},
 				{
-					ID:          "foopackager2:samd@2.0.0 - My Board Pro",
+					ID:          "foopackager2:samd@2.0.0 >> My Board Pro",
 					JSONPointer: "/packages/1/platforms/0/boards/1",
 				},
 				{
-					ID:          "foopackager2:mbed@1.1.1 - My Board",
+					ID:          "foopackager2:mbed@1.1.1 >> My Board",
 					JSONPointer: "/packages/1/platforms/1/boards/0",
 				},
 				{
-					ID:          "foopackager2:mbed@1.1.1 - My Board Pro",
+					ID:          "foopackager2:mbed@1.1.1 >> My Board Pro",
 					JSONPointer: "/packages/1/platforms/1/boards/1",
 				},
 			},
 			packageIndexToolsDependenciesAssertion: assert.NotNil,
 			packageIndexToolsDependenciesDataAssertion: []PackageIndexData{
 				{
-					ID:          "foopackager1:avr@1.0.0 - arduino:avr-gcc@4.8.1-arduino5",
+					ID:          "foopackager1:avr@1.0.0 >> arduino:avr-gcc@4.8.1-arduino5",
 					JSONPointer: "/packages/0/platforms/0/toolsDependencies/0",
 				},
 				{
-					ID:          "foopackager1:avr@1.0.0 - arduino:avrdude@6.0.1-arduino5",
+					ID:          "foopackager1:avr@1.0.0 >> arduino:avrdude@6.0.1-arduino5",
 					JSONPointer: "/packages/0/platforms/0/toolsDependencies/1",
 				},
 				{
-					ID:          "foopackager1:avr@1.0.1 - arduino:avr-gcc@7.3.0-atmel3.6.1-arduino7",
+					ID:          "foopackager1:avr@1.0.1 >> arduino:avr-gcc@7.3.0-atmel3.6.1-arduino7",
 					JSONPointer: "/packages/0/platforms/1/toolsDependencies/0",
 				},
 				{
-					ID:          "foopackager1:avr@1.0.1 - arduino:avrdude@6.3.0-arduino17",
+					ID:          "foopackager1:avr@1.0.1 >> arduino:avrdude@6.3.0-arduino17",
 					JSONPointer: "/packages/0/platforms/1/toolsDependencies/1",
 				},
 				{
-					ID:          "foopackager2:samd@2.0.0 - arduino:arm-none-eabi-gcc@7-2017q4",
+					ID:          "foopackager2:samd@2.0.0 >> arduino:arm-none-eabi-gcc@7-2017q4",
 					JSONPointer: "/packages/1/platforms/0/toolsDependencies/0",
 				},
 				{
-					ID:          "foopackager2:samd@2.0.0 - arduino:bossac@1.7.0-arduino3",
+					ID:          "foopackager2:samd@2.0.0 >> arduino:bossac@1.7.0-arduino3",
 					JSONPointer: "/packages/1/platforms/0/toolsDependencies/1",
 				},
 				{
-					ID:          "foopackager2:mbed@1.1.1 - arduino:openocd@0.11.0-arduino2",
+					ID:          "foopackager2:mbed@1.1.1 >> arduino:openocd@0.11.0-arduino2",
 					JSONPointer: "/packages/1/platforms/1/toolsDependencies/0",
 				},
 				{
-					ID:          "foopackager2:mbed@1.1.1 - arduino:arm-none-eabi-gcc@7-2017q4",
+					ID:          "foopackager2:mbed@1.1.1 >> arduino:arm-none-eabi-gcc@7-2017q4",
 					JSONPointer: "/packages/1/platforms/1/toolsDependencies/1",
 				},
 			},
 			packageIndexDiscoveryDependenciesAssertion: assert.NotNil,
 			packageIndexDiscoveryDependenciesDataAssertion: []PackageIndexData{
 				{
-					ID:          "foopackager1:avr@1.0.1 - arduino:ble-discovery",
+					ID:          "foopackager1:avr@1.0.1 >> arduino:ble-discovery",
 					JSONPointer: "/packages/0/platforms/1/discoveryDependencies/0",
 				},
 				{
-					ID:          "foopackager1:avr@1.0.1 - barpackager:carrier-pigeon-discovery",
+					ID:          "foopackager1:avr@1.0.1 >> barpackager:carrier-pigeon-discovery",
 					JSONPointer: "/packages/0/platforms/1/discoveryDependencies/1",
 				},
 				{
-					ID:          "foopackager2:samd@2.0.0 - arduino:ble-discovery",
+					ID:          "foopackager2:samd@2.0.0 >> arduino:ble-discovery",
 					JSONPointer: "/packages/1/platforms/0/discoveryDependencies/0",
 				},
 				{
-					ID:          "foopackager2:samd@2.0.0 - bazpackager:signal-flag-discovery",
+					ID:          "foopackager2:samd@2.0.0 >> bazpackager:signal-flag-discovery",
 					JSONPointer: "/packages/1/platforms/0/discoveryDependencies/1",
 				},
 				{
-					ID:          "foopackager2:mbed@1.1.1 - quxpackager:sneakernet-discovery",
+					ID:          "foopackager2:mbed@1.1.1 >> quxpackager:sneakernet-discovery",
 					JSONPointer: "/packages/1/platforms/1/discoveryDependencies/0",
 				},
 			},
@@ -200,19 +200,19 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			packageIndexSystemsAssertion: assert.NotNil,
 			packageIndexSystemsDataAssertion: []PackageIndexData{
 				{
-					ID:          "foopackager2:openocd@0.10.0-arduino1-static - i386-apple-darwin11",
+					ID:          "foopackager2:openocd@0.10.0-arduino1-static >> i386-apple-darwin11",
 					JSONPointer: "/packages/1/tools/0/systems/0",
 				},
 				{
-					ID:          "foopackager2:openocd@0.10.0-arduino1-static - x86_64-linux-gnu",
+					ID:          "foopackager2:openocd@0.10.0-arduino1-static >> x86_64-linux-gnu",
 					JSONPointer: "/packages/1/tools/0/systems/1",
 				},
 				{
-					ID:          "foopackager2:CMSIS@4.0.0-atmel - arm-linux-gnueabihf",
+					ID:          "foopackager2:CMSIS@4.0.0-atmel >> arm-linux-gnueabihf",
 					JSONPointer: "/packages/1/tools/1/systems/0",
 				},
 				{
-					ID:          "foopackager2:CMSIS@4.0.0-atmel - i686-mingw32",
+					ID:          "foopackager2:CMSIS@4.0.0-atmel >> i686-mingw32",
 					JSONPointer: "/packages/1/tools/1/systems/1",
 				},
 			},
@@ -297,7 +297,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/platforms/2/boards/0",
 				},
 				{
-					ID:          "foopackager2:megaavr@1.0.0 - My Board Pro",
+					ID:          "foopackager2:megaavr@1.0.0 >> My Board Pro",
 					JSONPointer: "/packages/1/platforms/2/boards/1",
 				},
 			},
@@ -348,7 +348,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/platforms/2/toolsDependencies/2",
 				},
 				{
-					ID:          "foopackager2:megaavr@1.0.0 - arduino:CMSIS@4.5.0",
+					ID:          "foopackager2:megaavr@1.0.0 >> arduino:CMSIS@4.5.0",
 					JSONPointer: "/packages/1/platforms/2/toolsDependencies/3",
 				},
 			},
@@ -395,7 +395,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/1",
 				},
 				{
-					ID:          "foopackager2:megaavr@1.0.0 - quxpackager:sneakernet-discovery",
+					ID:          "foopackager2:megaavr@1.0.0 >> quxpackager:sneakernet-discovery",
 					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/3",
 				},
 			},
@@ -518,7 +518,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/platforms/2/boards/0",
 				},
 				{
-					ID:          "foopackager2:megaavr@1.0.0 - My Board Pro",
+					ID:          "foopackager2:megaavr@1.0.0 >> My Board Pro",
 					JSONPointer: "/packages/1/platforms/2/boards/1",
 				},
 			},
@@ -569,7 +569,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/platforms/2/toolsDependencies/2",
 				},
 				{
-					ID:          "foopackager2:megaavr@1.0.0 - arduino:CMSIS@4.5.0",
+					ID:          "foopackager2:megaavr@1.0.0 >> arduino:CMSIS@4.5.0",
 					JSONPointer: "/packages/1/platforms/2/toolsDependencies/3",
 				},
 			},
@@ -616,7 +616,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/1",
 				},
 				{
-					ID:          "foopackager2:megaavr@1.0.0 - quxpackager:sneakernet-discovery",
+					ID:          "foopackager2:megaavr@1.0.0 >> quxpackager:sneakernet-discovery",
 					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/3",
 				},
 			},

--- a/internal/rule/rulefunction/packageindex_test.go
+++ b/internal/rule/rulefunction/packageindex_test.go
@@ -765,7 +765,7 @@ func TestPackageIndexPackagesPlatformsBoardsIncorrectType(t *testing.T) {
 func TestPackageIndexPackagesPlatformsBoardsAdditionalProperties(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Additional packages[].platforms[].boards[] properties", "packages-platforms-boards-additional-properties", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 - My Board$"},
+		{"Additional packages[].platforms[].boards[] properties", "packages-platforms-boards-additional-properties", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 >> My Board$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -825,7 +825,7 @@ func TestPackageIndexPackagesPlatformsToolsDependenciesIncorrectType(t *testing.
 func TestPackageIndexPackagesPlatformsToolsDependenciesAdditionalProperties(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Additional packages[].platforms[].toolsDependencies[] properties", "packages-platforms-toolsdependencies-additional-properties", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 - arduino:avr-gcc@7\\.3\\.0-atmel3\\.6\\.1-arduino7$"},
+		{"Additional packages[].platforms[].toolsDependencies[] properties", "packages-platforms-toolsdependencies-additional-properties", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 >> arduino:avr-gcc@7\\.3\\.0-atmel3\\.6\\.1-arduino7$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -915,7 +915,7 @@ func TestPackageIndexPackagesPlatformsToolsDependenciesVersionIncorrectType(t *t
 func TestPackageIndexPackagesPlatformsToolsDependenciesVersionNonRelaxedSemver(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].platforms[].toolsDependencies[].version not relaxed semver", "packages-platforms-toolsdependencies-version-non-relaxed-semver", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 - arduino:avr-gcc@foo$"},
+		{"packages[].platforms[].toolsDependencies[].version not relaxed semver", "packages-platforms-toolsdependencies-version-non-relaxed-semver", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 >> arduino:avr-gcc@foo$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -925,7 +925,7 @@ func TestPackageIndexPackagesPlatformsToolsDependenciesVersionNonRelaxedSemver(t
 func TestPackageIndexPackagesPlatformsToolsDependenciesVersionNonSemver(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].platforms[].toolsDependencies[].version not semver", "packages-platforms-toolsdependencies-version-not-semver", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 - arduino:avr-gcc@7\\.3$"},
+		{"packages[].platforms[].toolsDependencies[].version not semver", "packages-platforms-toolsdependencies-version-not-semver", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 >> arduino:avr-gcc@7\\.3$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -945,7 +945,7 @@ func TestPackageIndexPackagesPlatformsDiscoveryDependenciesIncorrectType(t *test
 func TestPackageIndexPackagesPlatformsDiscoveryDependenciesAdditionalProperties(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Additional packages[].platforms[].discoveryDependencies[] properties", "packages-platforms-discoverydependencies-additional-properties", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 - arduino:ble-discovery$"},
+		{"Additional packages[].platforms[].discoveryDependencies[] properties", "packages-platforms-discoverydependencies-additional-properties", ruleresult.Fail, "^foopackager:avr@1\\.0\\.0 >> arduino:ble-discovery$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1135,7 +1135,7 @@ func TestPackageIndexPackagesToolsSystemsIncorrectType(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsAdditionalProperties(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Additional packages[].tools[].systems[] properties", "packages-tools-systems-additional-properties", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Additional packages[].tools[].systems[] properties", "packages-tools-systems-additional-properties", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1165,7 +1165,7 @@ func TestPackageIndexPackagesToolsSystemsHostIncorrectType(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsHostInvalid(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Invalid packages[].tools[].systems[].host format", "packages-tools-systems-host-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - foo$"},
+		{"Invalid packages[].tools[].systems[].host format", "packages-tools-systems-host-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> foo$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1175,7 +1175,7 @@ func TestPackageIndexPackagesToolsSystemsHostInvalid(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsUrlMissing(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].tools[].systems[].url missing", "packages-tools-systems-url-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"packages[].tools[].systems[].url missing", "packages-tools-systems-url-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1185,7 +1185,7 @@ func TestPackageIndexPackagesToolsSystemsUrlMissing(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsUrlIncorrectType(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Incorrect packages[].tools[].systems[].url type", "packages-tools-systems-url-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Incorrect packages[].tools[].systems[].url type", "packages-tools-systems-url-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1195,7 +1195,7 @@ func TestPackageIndexPackagesToolsSystemsUrlIncorrectType(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsUrlInvalidFormat(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Incorrect packages[].tools[].systems[].url format", "packages-tools-systems-url-invalid-format", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Incorrect packages[].tools[].systems[].url format", "packages-tools-systems-url-invalid-format", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1205,7 +1205,7 @@ func TestPackageIndexPackagesToolsSystemsUrlInvalidFormat(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsURLDeadLink(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Dead URLs", "packages-tools-systems-url-dead", ruleresult.Fail, "^foopackager:CMSIS@4\\.0\\.0-atmel - arm-linux-gnueabihf, foopackager:CMSIS@4\\.0\\.0-atmel - i686-mingw32$"},
+		{"Dead URLs", "packages-tools-systems-url-dead", ruleresult.Fail, "^foopackager:CMSIS@4\\.0\\.0-atmel >> arm-linux-gnueabihf, foopackager:CMSIS@4\\.0\\.0-atmel >> i686-mingw32$"},
 		{"Valid URL", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1215,7 +1215,7 @@ func TestPackageIndexPackagesToolsSystemsURLDeadLink(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsArchiveFileNameMissing(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].tools[].systems[].archiveFileName missing", "packages-tools-systems-archivefilename-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"packages[].tools[].systems[].archiveFileName missing", "packages-tools-systems-archivefilename-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1225,7 +1225,7 @@ func TestPackageIndexPackagesToolsSystemsArchiveFileNameMissing(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsArchiveFileNameIncorrectType(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Incorrect packages[].tools[].systems[].archiveFileName type", "packages-tools-systems-archivefilename-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Incorrect packages[].tools[].systems[].archiveFileName type", "packages-tools-systems-archivefilename-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1235,7 +1235,7 @@ func TestPackageIndexPackagesToolsSystemsArchiveFileNameIncorrectType(t *testing
 func TestPackageIndexPackagesToolsSystemsArchiveFileNameLTMinLength(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].tools[].systems[].archiveFileName < min length", "packages-tools-systems-archivefilename-length-lt", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"packages[].tools[].systems[].archiveFileName < min length", "packages-tools-systems-archivefilename-length-lt", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1245,7 +1245,7 @@ func TestPackageIndexPackagesToolsSystemsArchiveFileNameLTMinLength(t *testing.T
 func TestPackageIndexPackagesToolsSystemsArchiveFileNameInvalid(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Invalid packages[].tools[].systems[].archiveFileName format", "packages-tools-systems-archivefilename-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Invalid packages[].tools[].systems[].archiveFileName format", "packages-tools-systems-archivefilename-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1255,7 +1255,7 @@ func TestPackageIndexPackagesToolsSystemsArchiveFileNameInvalid(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsChecksumMissing(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].tools[].systems[].checksum missing", "packages-tools-systems-checksum-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"packages[].tools[].systems[].checksum missing", "packages-tools-systems-checksum-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1265,7 +1265,7 @@ func TestPackageIndexPackagesToolsSystemsChecksumMissing(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsChecksumIncorrectType(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Incorrect packages[].tools[].systems[].checksum type", "packages-tools-systems-checksum-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Incorrect packages[].tools[].systems[].checksum type", "packages-tools-systems-checksum-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1275,7 +1275,7 @@ func TestPackageIndexPackagesToolsSystemsChecksumIncorrectType(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsChecksumInvalid(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Invalid packages[].tools[].systems[].checksum format", "packages-tools-systems-checksum-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Invalid packages[].tools[].systems[].checksum format", "packages-tools-systems-checksum-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1285,7 +1285,7 @@ func TestPackageIndexPackagesToolsSystemsChecksumInvalid(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsChecksumDiscouragedAlgorithm(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].tools[].systems[].checksum uses discouraged algorithm", "packages-tools-systems-checksum-discouraged", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"packages[].tools[].systems[].checksum uses discouraged algorithm", "packages-tools-systems-checksum-discouraged", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1295,7 +1295,7 @@ func TestPackageIndexPackagesToolsSystemsChecksumDiscouragedAlgorithm(t *testing
 func TestPackageIndexPackagesToolsSystemsSizeMissing(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"packages[].tools[].systems[].size missing", "packages-tools-systems-size-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"packages[].tools[].systems[].size missing", "packages-tools-systems-size-missing", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1305,7 +1305,7 @@ func TestPackageIndexPackagesToolsSystemsSizeMissing(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsSizeIncorrectType(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Incorrect packages[].tools[].systems[].size type", "packages-tools-systems-size-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Incorrect packages[].tools[].systems[].size type", "packages-tools-systems-size-incorrect-type", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 
@@ -1315,7 +1315,7 @@ func TestPackageIndexPackagesToolsSystemsSizeIncorrectType(t *testing.T) {
 func TestPackageIndexPackagesToolsSystemsSizeInvalid(t *testing.T) {
 	testTables := []packageIndexRuleFunctionTestTable{
 		{"Invalid JSON", "invalid-JSON", ruleresult.NotRun, ""},
-		{"Invalid packages[].tools[].systems[].size format", "packages-tools-systems-size-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 - aarch64-linux-gnu$"},
+		{"Invalid packages[].tools[].systems[].size format", "packages-tools-systems-size-invalid", ruleresult.Fail, "^foopackager:openocd@0\\.11\\.0-arduino2 >> aarch64-linux-gnu$"},
 		{"Valid", "valid-package-index", ruleresult.Pass, ""},
 	}
 


### PR DESCRIPTION
Since package index data occurs in arrays, the rules must indicate to the user the specific element(s) in violation. In the case of standard components (e.g. platform), the form of the IDs is well established (e.g., `arduino:avr@1.8.3`). However, that I know of, there is no standard form for unequivocally identifying a package index data subcomponent (e.g., a tool dependency of a specific platform release).

I arbitrarily chose a dash to combine the IDs of the two components (e.g., `arduino:avr-gcc@7.3.0-atmel3.6.1-arduino7 - x86_64-linux-gnu`). I received feedback that this was not very clear, with a suggestion to use ">>" instead of the "-" (e.g., `arduino:avr-gcc@7.3.0-atmel3.6.1-arduino7 >> x86_64-linux-gnu`).