### PR TITLE
Sync "Check Certificates" CI workflow with template

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -27,7 +27,6 @@ jobs:
       (github.event_name != 'pull_request' && github.repository == 'arduino/arduino-lint') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'arduino/arduino-lint')
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
 

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -10,13 +10,13 @@ on:
     paths:
       - ".github/workflows/check-certificates.ya?ml"
   schedule:
-    # run every 10 hours
+    # Run every 10 hours.
     - cron: "0 */10 * * *"
   workflow_dispatch:
   repository_dispatch:
 
 env:
-  # Begin notifications when there are less than this many days remaining before expiration
+  # Begin notifications when there are less than this many days remaining before expiration.
   EXPIRATION_WARNING_PERIOD: 30
 
 jobs:
@@ -32,14 +32,15 @@ jobs:
 
       matrix:
         certificate:
-          - identifier: macOS signing certificate # Text used to identify the certificate in notifications
-            certificate-secret: INSTALLER_CERT_MAC_P12 # The name of the secret that contains the certificate
-            password-secret: INSTALLER_CERT_MAC_PASSWORD # The name of the secret that contains the certificate password
+          # Additional certificate definitions can be added to this list.
+          - identifier: macOS signing certificate # Text used to identify certificate in notifications.
+            certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
+            password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
 
     steps:
       - name: Set certificate path environment variable
         run: |
-          # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "CERTIFICATE_PATH=${{ runner.temp }}/certificate.p12" >> "$GITHUB_ENV"
 
       - name: Decode certificate
@@ -61,7 +62,6 @@ jobs:
             exit 1
           )
 
-      # See: https://github.com/rtCamp/action-slack-notify
       - name: Slack notification of certificate verification failure
         if: failure()
         env:
@@ -101,7 +101,7 @@ jobs:
 
           DAYS_BEFORE_EXPIRATION="$((($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24))"
 
-          # Display the expiration information in the log
+          # Display the expiration information in the log.
           echo "Certificate expiration date: $EXPIRATION_DATE"
           echo "Days remaining before expiration: $DAYS_BEFORE_EXPIRATION"
 
@@ -116,7 +116,7 @@ jobs:
           fi
 
       - name: Slack notification of pending certificate expiration
-        # Don't send spurious expiration notification if verification fails
+        # Don't send spurious expiration notification if verification fails.
         if: failure() && steps.check-expiration.outcome == 'failure'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -1,14 +1,12 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-certificates.md
 name: Check Certificates
 
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
   schedule:
     # run every 10 hours
     - cron: "0 */10 * * *"
-  # workflow_dispatch event allows the workflow to be triggered manually.
-  # This could be used to run an immediate check after updating certificate secrets.
-  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
 
 env:

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -4,6 +4,8 @@ name: Check Certificates
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
+    paths:
+      - ".github/workflows/check-certificates.ya?ml"
   schedule:
     # run every 10 hours
     - cron: "0 */10 * * *"

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-certificates.md
 name: Check Certificates
 
 on:

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   check-certificates:
+    name: ${{ matrix.certificate.identifier }}
     # Only run when the workflow will have access to the certificate secrets.
     if: >
       (github.event_name != 'pull_request' && github.repository == 'arduino/arduino-lint') ||

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -65,7 +65,6 @@ jobs:
       # See: https://github.com/rtCamp/action-slack-notify
       - name: Slack notification of certificate verification failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
@@ -74,6 +73,7 @@ jobs:
             :warning::warning::warning::warning:
           SLACK_COLOR: danger
           MSG_MINIMAL: true
+        uses: rtCamp/action-slack-notify@v2
 
       - name: Get days remaining before certificate expiration date
         env:
@@ -119,7 +119,6 @@ jobs:
       - name: Slack notification of pending certificate expiration
         # Don't send spurious expiration notification if verification fails
         if: failure() && steps.check-expiration.outcome == 'failure'
-        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
@@ -128,3 +127,4 @@ jobs:
             :warning::warning::warning::warning:
           SLACK_COLOR: danger
           MSG_MINIMAL: true
+        uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -1,4 +1,4 @@
-name: Check for issues with signing certificates
+name: Check Certificates
 
 on:
   push:

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -6,6 +6,9 @@ on:
   push:
     paths:
       - ".github/workflows/check-certificates.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-certificates.ya?ml"
   schedule:
     # run every 10 hours
     - cron: "0 */10 * * *"
@@ -17,8 +20,10 @@ env:
 
 jobs:
   check-certificates:
-    # This workflow would always fail in forks
-    if: github.repository == 'arduino/arduino-lint'
+    # Only run when the workflow will have access to the certificate secrets.
+    if: >
+      (github.event_name != 'pull_request' && github.repository == 'arduino/arduino-lint') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'arduino/arduino-lint')
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -13,6 +13,7 @@ on:
     # run every 10 hours
     - cron: "0 */10 * * *"
   workflow_dispatch:
+  repository_dispatch:
 
 env:
   # Begin notifications when there are less than this many days remaining before expiration

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Slack notification of certificate verification failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
             :warning::warning::warning::warning:
             WARNING: ${{ github.repository }} ${{ matrix.certificate.identifier }} verification failed!!!
@@ -120,7 +120,7 @@ jobs:
         # Don't send spurious expiration notification if verification fails
         if: failure() && steps.check-expiration.outcome == 'failure'
         env:
-          SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
             :warning::warning::warning::warning:
             WARNING: ${{ github.repository }} ${{ matrix.certificate.identifier }} will expire in ${{ steps.get-days-before-expiration.outputs.days }} days!!!

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Nightly Status](https://github.com/arduino/arduino-lint/workflows/Nightly%20build/badge.svg)](https://github.com/arduino/arduino-lint/actions?workflow=Nightly+build)
 [![Docs Status](https://github.com/arduino/arduino-lint/workflows/Publish%20documentation/badge.svg)](https://github.com/arduino/arduino-lint/actions?workflow=Publish+documentation)
 [![Codecov](https://codecov.io/gh/arduino/arduino-lint/branch/main/graph/badge.svg?token=nprqPQMbdh)](https://codecov.io/gh/arduino/arduino-lint)
+[![Check Certificates status](https://github.com/arduino/arduino-lint/actions/workflows/check-certificates.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-certificates.yml)
 
 **Arduino Lint** is a command line tool that checks for common problems in [Arduino](https://www.arduino.cc/) projects:
 


### PR DESCRIPTION
We have assembled a collection of reusable GitHub Actions workflows:
https://github.com/arduino/tooling-project-assets
These workflows will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made to the "template" workflow, and these are introduced via this pull request.

---
This changes the name of the repository secret that contains the Slack webhook and I have already added the new secret.