### PR TITLE
Add CI workflow to check general file formatting

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,8 @@
+{
+  "Exclude": [
+    "LICENSE.txt",
+    "poetry.lock",
+    "^internal/rule/schema/schemadata/bindata.go$",
+    "^internal/rule/schema/testdata/bindata.go$"
+  ]
+}

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -1,0 +1,53 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
+name: Check General Formatting
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Download latest editorconfig-checker release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: editorconfig-checker/editorconfig-checker
+          excludes: prerelease, draft
+          asset: linux-amd64.tar.gz
+          target: ${{ env.EC_INSTALL_PATH }}
+
+      - name: Install editorconfig-checker
+        run: |
+          cd "${{ env.EC_INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
+          # Give the binary a standard name
+          mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
+
+      - name: Check formatting
+        run: task --silent general:check-formatting

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Check Markdown status](https://github.com/arduino/arduino-lint/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-markdown-task.yml)
 [![Docs Status](https://github.com/arduino/arduino-lint/workflows/Publish%20documentation/badge.svg)](https://github.com/arduino/arduino-lint/actions?workflow=Publish+documentation)
 [![Codecov](https://codecov.io/gh/arduino/arduino-lint/branch/main/graph/badge.svg?token=nprqPQMbdh)](https://codecov.io/gh/arduino/arduino-lint)
+[![Check General Formatting status](https://github.com/arduino/arduino-lint/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-general-formatting-task.yml)
 [![Check Certificates status](https://github.com/arduino/arduino-lint/actions/workflows/check-certificates.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-certificates.yml)
 
 **Arduino Lint** is a command line tool that checks for common problems in [Arduino](https://www.arduino.cc/) projects:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,6 +44,7 @@ tasks:
       - task: python:check
       - task: docs:check
       - task: config:check
+      - task: general:check-formatting
       - task: check-spelling
 
   lint:
@@ -60,6 +61,7 @@ tasks:
     cmds:
       - task: docs:check-formatting
       - task: config:check-formatting
+      - task: general:check-formatting
 
   format:
     desc: Format all files
@@ -311,6 +313,17 @@ tasks:
     cmds:
       - npx {{ .PRETTIER }} --write "**/*.{yml,yaml}"
       - npx {{ .PRETTIER }} --write "**/*.json"
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+  general:check-formatting:
+    desc: Check basic formatting style of all files
+    cmds:
+      - |
+        if ! which ec &>/dev/null; then
+          echo "ec not found or not in PATH. Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+          exit 1
+        fi
+      - ec
 
   check-spelling:
     desc: Check for commonly misspelled words


### PR DESCRIPTION
On every push, pull request, and periodically, use [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) check whether the repository's files are formatted according to [`.editorconfig`](https://editorconfig.org/).
