### PR TITLE
Sync GitHub Actions workflow validation CI workflow with template

### DIFF
--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -1,36 +1,35 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-workflows-task.md
 name: Check Workflows
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
     paths:
-      - ".github/workflows/lint-config.yml"
       - ".github/workflows/*.ya?ml"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
-      - ".github/workflows/lint-config.yml"
       - ".github/workflows/*.ya?ml"
       - "Taskfile.ya?ml"
   schedule:
-    # Run every Tuesday at 03:00 UTC to catch breakage caused by changes to the GitHub Actions workflow schema
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
     - cron: "0 8 * * TUE"
   workflow_dispatch:
   repository_dispatch:
 
 jobs:
-  lint:
+  validate:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout local repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Taskfile
+      - name: Install Task
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
-      - name: Lint configuration files
+      - name: Validate workflows
         run: task --silent ci:validate
-

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -1,4 +1,4 @@
-name: Lint configuration files
+name: Check Workflows
 
 on:
   push:

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -4,13 +4,13 @@ on:
   push:
     paths:
       - ".github/workflows/lint-config.yml"
-      - "Taskfile.yml"
-      - ".github/workflows/*.yml"
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/lint-config.yml"
-      - "Taskfile.yml"
-      - ".github/workflows/*.yml"
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
   schedule:
     # Run every Tuesday at 03:00 UTC to catch breakage caused by changes to the GitHub Actions workflow schema
     - cron: "0 3 * * 2"

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -29,4 +29,5 @@ jobs:
           version: 3.x
 
       - name: Lint configuration files
-        run: task config:lint
+        run: task ci:validate
+

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -29,5 +29,5 @@ jobs:
           version: 3.x
 
       - name: Lint configuration files
-        run: task ci:validate
+        run: task --silent ci:validate
 

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -1,5 +1,6 @@
 name: Check Workflows
 
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
     paths:
@@ -14,6 +15,8 @@ on:
   schedule:
     # Run every Tuesday at 03:00 UTC to catch breakage caused by changes to the GitHub Actions workflow schema
     - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/lint-config.yml
+++ b/.github/workflows/lint-config.yml
@@ -13,7 +13,7 @@ on:
       - "Taskfile.ya?ml"
   schedule:
     # Run every Tuesday at 03:00 UTC to catch breakage caused by changes to the GitHub Actions workflow schema
-    - cron: "0 3 * * 2"
+    - cron: "0 8 * * TUE"
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Codecov](https://codecov.io/gh/arduino/arduino-lint/branch/main/graph/badge.svg?token=nprqPQMbdh)](https://codecov.io/gh/arduino/arduino-lint)
 [![Check Prettier Formatting status](https://github.com/arduino/arduino-lint/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-prettier-formatting-task.yml)
 [![Check General Formatting status](https://github.com/arduino/arduino-lint/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-general-formatting-task.yml)
+[![Check Workflows status](https://github.com/arduino/arduino-lint/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-workflows-task.yml)
 [![Check Shell Scripts status](https://github.com/arduino/arduino-lint/actions/workflows/check-shell-task.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-shell-task.yml)
 [![Check Certificates status](https://github.com/arduino/arduino-lint/actions/workflows/check-certificates.yml/badge.svg)](https://github.com/arduino/arduino-lint/actions/workflows/check-certificates.yml)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -350,6 +350,7 @@ tasks:
           --package=ajv-cli \
           --package=ajv-formats \
           ajv validate \
+            --all-errors \
             --strict=false \
             -c ajv-formats \
             -s "{{.WORKFLOW_SCHEMA_PATH}}" \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -334,11 +334,14 @@ tasks:
   workflow:validate:
     desc: Validate GitHub Actions workflows against JSON schema
     vars:
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
+      WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow
       WORKFLOW_SCHEMA_PATH:
         sh: mktemp -t workflow-schema-XXXXXXXXXX.json
+      WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
     cmds:
-      - wget --output-document={{.WORKFLOW_SCHEMA_PATH}} https://json.schemastore.org/github-workflow
-      - npx ajv-cli validate --strict=false -s {{.WORKFLOW_SCHEMA_PATH}} -d "./.github/workflows/*.{yml,yaml}"
+      - wget --output-document={{.WORKFLOW_SCHEMA_PATH}} {{.WORKFLOW_SCHEMA_URL}}
+      - npx ajv-cli validate --strict=false -s {{.WORKFLOW_SCHEMA_PATH}} -d "{{.WORKFLOWS_DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
   general:check-formatting:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -347,8 +347,11 @@ tasks:
           {{.WORKFLOW_SCHEMA_URL}}
       - |
         npx \
-          ajv-cli validate \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
             --strict=false \
+            -c ajv-formats \
             -s "{{.WORKFLOW_SCHEMA_PATH}}" \
             -d "{{.WORKFLOWS_DATA_PATH}}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -332,7 +332,7 @@ tasks:
       - task: workflow:validate
 
   ci:validate:
-    desc: Validate GitHub Actions workflows against JSON schema
+    desc: Validate GitHub Actions workflows against their JSON schema
     vars:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
       WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -337,8 +337,8 @@ tasks:
       WORKFLOW_SCHEMA_PATH:
         sh: mktemp -t workflow-schema-XXXXXXXXXX.json
     cmds:
-      - wget --output-document={{ .WORKFLOW_SCHEMA_PATH }} https://json.schemastore.org/github-workflow
-      - npx ajv-cli validate --strict=false -s {{ .WORKFLOW_SCHEMA_PATH }} -d "./.github/workflows/*.{yml,yaml}"
+      - wget --output-document={{.WORKFLOW_SCHEMA_PATH}} https://json.schemastore.org/github-workflow
+      - npx ajv-cli validate --strict=false -s {{.WORKFLOW_SCHEMA_PATH}} -d "./.github/workflows/*.{yml,yaml}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
   general:check-formatting:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -340,8 +340,16 @@ tasks:
         sh: mktemp -t workflow-schema-XXXXXXXXXX.json
       WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
     cmds:
-      - wget --output-document="{{.WORKFLOW_SCHEMA_PATH}}" {{.WORKFLOW_SCHEMA_URL}}
-      - npx ajv-cli validate --strict=false -s "{{.WORKFLOW_SCHEMA_PATH}}" -d "{{.WORKFLOWS_DATA_PATH}}"
+      - |
+        wget \
+          --output-document="{{.WORKFLOW_SCHEMA_PATH}}" \
+          {{.WORKFLOW_SCHEMA_URL}}
+      - |
+        npx \
+          ajv-cli validate \
+            --strict=false \
+            -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+            -d "{{.WORKFLOWS_DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
   general:check-formatting:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -331,6 +331,7 @@ tasks:
     cmds:
       - task: workflow:validate
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
   ci:validate:
     desc: Validate GitHub Actions workflows against their JSON schema
     vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -342,6 +342,7 @@ tasks:
     cmds:
       - |
         wget \
+          --quiet \
           --output-document="{{.WORKFLOW_SCHEMA_PATH}}" \
           {{.WORKFLOW_SCHEMA_URL}}
       - |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -331,7 +331,7 @@ tasks:
     cmds:
       - task: workflow:validate
 
-  workflow:validate:
+  ci:validate:
     desc: Validate GitHub Actions workflows against JSON schema
     vars:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -333,6 +333,9 @@ tasks:
 
   workflow:validate:
     desc: Validate GitHub Actions workflows against JSON schema
+    vars:
+      WORKFLOW_SCHEMA_PATH:
+        sh: mktemp -t workflow-schema-XXXXXXXXXX.json
     cmds:
       - wget --output-document={{ .WORKFLOW_SCHEMA_PATH }} https://json.schemastore.org/github-workflow
       - npx ajv-cli validate --strict=false -s {{ .WORKFLOW_SCHEMA_PATH }} -d "./.github/workflows/*.{yml,yaml}"
@@ -395,8 +398,6 @@ vars:
   DOCS_REMOTE: "origin"
 
   PRETTIER: prettier@2.1.2
-
-  WORKFLOW_SCHEMA_PATH: "$(mktemp -t gha-workflow-schema-XXXXXXXXXX.json)"
 
   CODESPELL_SKIP_OPTION: '--skip "./.git,go.mod,go.sum,./arduino-lint,./arduino-lint.exe,./internal/rule/rulefunction/testdata/libraries/MisspelledSentenceParagraphValue/library.properties,./site"'
   CODESPELL_IGNORE_WORDS_OPTION: "--ignore-words ./etc/codespell-ignore-words-list.txt"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -340,8 +340,8 @@ tasks:
         sh: mktemp -t workflow-schema-XXXXXXXXXX.json
       WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
     cmds:
-      - wget --output-document={{.WORKFLOW_SCHEMA_PATH}} {{.WORKFLOW_SCHEMA_URL}}
-      - npx ajv-cli validate --strict=false -s {{.WORKFLOW_SCHEMA_PATH}} -d "{{.WORKFLOWS_DATA_PATH}}"
+      - wget --output-document="{{.WORKFLOW_SCHEMA_PATH}}" {{.WORKFLOW_SCHEMA_URL}}
+      - npx ajv-cli validate --strict=false -s "{{.WORKFLOW_SCHEMA_PATH}}" -d "{{.WORKFLOWS_DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
   general:check-formatting:


### PR DESCRIPTION
We have assembled a collection of reusable GitHub Actions workflows:
https://github.com/arduino/tooling-project-assets
These workflows will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made in the upstream "template" workflow, and those are introduced to this repository via this pull request.