### PR TITLE
Sync license check CI workflow with template

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
 name: Check License
 
 env:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -53,14 +53,14 @@ jobs:
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
           if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
-            echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $EXPECTED_LICENSE_FILENAME"
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
           if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
-            echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${EXPECTED_LICENSE_TYPE}\""
             EXIT_STATUS=1
           fi
 

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -5,6 +5,7 @@ env:
   # SPDX identifier: https://spdx.org/licenses/
   EXPECTED_LICENSE_TYPE: GPL-3.0
 
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
     paths:
@@ -23,6 +24,8 @@ on:
       - "[lL][iI][cC][eE][nN][cCsS][eE]*"
       - "[oO][fF][lL]*"
       - "[pP][aA][tT][eE][nN][tT][sS]*"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   check-license:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -32,10 +32,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout local repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: ruby/setup-ruby@v1
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby # Install latest version
 

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,10 +1,14 @@
 name: Check License
 
+env:
+  EXPECTED_LICENSE_FILENAME: LICENSE.txt
+  # SPDX identifier: https://spdx.org/licenses/
+  EXPECTED_LICENSE_TYPE: GPL-3.0
+
 on:
   push:
     paths:
       - ".github/workflows/check-license.ya?ml"
-      - "Taskfile.yml"
       # Recognized license files. See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
       - "COPYING*"
       - "LICENCE*"
@@ -12,7 +16,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/check-license.ya?ml"
-      - "Taskfile.yml"
       - "COPYING*"
       - "LICENCE*"
       - "LICENSE*"
@@ -25,12 +28,6 @@ jobs:
       - name: Checkout local repository
         uses: actions/checkout@v2
 
-      - name: Install Taskfile
-        uses: arduino/setup-task@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby # Install latest version
@@ -40,4 +37,20 @@ jobs:
 
       # See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository
       - name: Check license file
-        run: task --silent docs:check-license
+        run: |
+          # See: https://github.com/licensee/licensee
+          LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
+
+          DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
+          echo "Detected license file: $DETECTED_LICENSE_FILE"
+          if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
+            echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+            exit 1
+          fi
+
+          DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
+          echo "Detected license type: $DETECTED_LICENSE_TYPE"
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
+            echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
+            exit 1
+          fi

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -43,7 +43,6 @@ jobs:
       - name: Install licensee
         run: gem install licensee
 
-      # See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository
       - name: Check license file
         run: |
           EXIT_STATUS=0

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -9,16 +9,16 @@ on:
   push:
     paths:
       - ".github/workflows/check-license.ya?ml"
-      # Recognized license files. See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
-      - "COPYING*"
-      - "LICENCE*"
-      - "LICENSE*"
+      # See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
   pull_request:
     paths:
       - ".github/workflows/check-license.ya?ml"
-      - "COPYING*"
-      - "LICENCE*"
-      - "LICENSE*"
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
 
 jobs:
   check-license:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -13,12 +13,16 @@ on:
       - "[cC][oO][pP][yY][iI][nN][gG]*"
       - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
       - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
   pull_request:
     paths:
       - ".github/workflows/check-license.ya?ml"
       - "[cC][oO][pP][yY][iI][nN][gG]*"
       - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
       - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
 
 jobs:
   check-license:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -3,7 +3,7 @@ name: Check License
 on:
   push:
     paths:
-      - ".github/workflows/lint-documentation.yml"
+      - ".github/workflows/check-license.ya?ml"
       - "Taskfile.yml"
       # Recognized license files. See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
       - "COPYING*"
@@ -11,7 +11,7 @@ on:
       - "LICENSE*"
   pull_request:
     paths:
-      - ".github/workflows/lint-documentation.yml"
+      - ".github/workflows/check-license.ya?ml"
       - "Taskfile.yml"
       - "COPYING*"
       - "LICENCE*"

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -46,6 +46,7 @@ jobs:
       # See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository
       - name: Check license file
         run: |
+          EXIT_STATUS=0
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 
@@ -53,12 +54,14 @@ jobs:
           echo "Detected license file: $DETECTED_LICENSE_FILE"
           if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
             echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
-            exit 1
+            EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
           if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
             echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
-            exit 1
+            EXIT_STATUS=1
           fi
+
+          exit $EXIT_STATUS

--- a/.github/workflows/lint-documentation.yml
+++ b/.github/workflows/lint-documentation.yml
@@ -1,4 +1,4 @@
-name: Lint documentation files
+name: Check License
 
 on:
   push:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,35 +224,6 @@ tasks:
       - task: markdown:fix
       - task: markdown:check-links
 
-  docs:lint:
-    desc: Lint documentation files
-    cmds:
-      - task: docs:check-license
-
-  docs:check-license:
-    desc: Check if the license file is correctly formatted
-    cmds:
-      - |
-        EXPECTED_LICENSE_FILE="\"LICENSE.txt\""
-        EXPECTED_LICENSE_TYPE="\"GPL-3.0\"" # https://spdx.org/licenses/
-
-        # See: https://github.com/licensee/licensee
-        LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
-
-        DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
-        echo "Detected license file: $DETECTED_LICENSE_FILE"
-        if [ "$DETECTED_LICENSE_FILE" != "$EXPECTED_LICENSE_FILE" ]; then
-          echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILE"
-          exit 1
-        fi
-
-        DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
-        echo "Detected license type: $DETECTED_LICENSE_TYPE"
-        if [ "$DETECTED_LICENSE_TYPE" != "$EXPECTED_LICENSE_TYPE" ]; then
-          echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
-          exit 1
-        fi
-
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-shell-task/Taskfile.yml
   shell:check:
     desc: Check for problems with shell scripts


### PR DESCRIPTION
We have assembled a collection of reusable GitHub Actions workflows:
https://github.com/arduino/tooling-project-assets
These workflows will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made in the upstream "template" workflow, and those are introduced to this repository via this pull request.