### PR TITLE
Run Go module configuration sync check also on docsgen module

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -11,15 +11,15 @@ on:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
       - "Taskfile.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   pull_request:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
       - "Taskfile.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   workflow_dispatch:
   repository_dispatch:
@@ -119,7 +119,16 @@ jobs:
         run: git diff --color --exit-code
 
   check-config:
+    name: check-config (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
+          - path: docsgen
 
     steps:
       - name: Checkout repository
@@ -131,6 +140,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run go mod tidy
+        working-directory: ${{ matrix.module.path }}
         run: go mod tidy
 
       - name: Check whether any tidying was needed


### PR DESCRIPTION
The `check-config` job of the "Check Go" workflow runs a check to see whether there were any missed updates to the
`go.mod` and `go.sum` files. Previously, this was only done for the main module. But there is an additional module for
generating the website's command reference content the update of which might easily be overlooked. The CI check was not
applied to this module, which could allow its metadata to get out of date.

The use of a job matrix allows the workflow to easily accomodate the future addition of more modules to the repository by
simply adding their path to the matrix array.