### PR TITLE
Use Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# See: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
+  # See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,19 @@ updates:
     labels:
       - "topic: infrastructure"
 
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+  - package-ecosystem: gomod
+    directory: /docsgen/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+
   - package-ecosystem: pip
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,10 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
Dependabot will periodically check the versions of all the project's GitHub Actions, Go, and Python dependencies If any are found to be outdated, it will submit a pull request to update them.
