### PR TITLE
Replace broken website publishing script link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -272,4 +272,5 @@ documentation website. Every time a change is pushed to this special branch, Git
 to pull the change and publish a new version of the website. Do not open Pull Requests to push changes to the `gh-pages`
 branch; that will be done exclusively from the CI.
 
-For details on the documentation publishing system, see: https://github.com/arduino/arduino-lint/blob/main/docs/build.py
+For details on the documentation publishing system, see:
+https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md


### PR DESCRIPTION
The Python script used by the website publishing system was moved during the sync to the "template" version but the link to it from `CONTRIBUTING.md` was not updated accordingly.

The reworking of the system that broke the link also removed the documentation content from that file. That content has been moved to the documentation for the template system. Since this content is for maintainers, and is not of interest to the average contributor, I think it is find to maintain that content in a single place in the assets repository, and link to it there.