### PR TITLE
Use workflow variables for tool versions in all workflows

### DIFF
--- a/.github/workflows/check-code-generation-task.yml
+++ b/.github/workflows/check-code-generation-task.yml
@@ -1,5 +1,9 @@
 name: Check Code Generation
 
+env:
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: "1.16"
+
 on:
   push:
     paths:
@@ -29,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1

--- a/.github/workflows/check-code-generation-task.yml
+++ b/.github/workflows/check-code-generation-task.yml
@@ -18,9 +18,6 @@ on:
       - "**/*.go"
       - "etc/schemas/**/*.json"
 
-env:
-  BUILDS_ARTIFACT: build-artifacts
-
 jobs:
   test-go:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -1,6 +1,10 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
 name: Deploy Website
 
+env:
+  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  PYTHON_VERSION: "3.9"
+
 on:
   push:
     branches:
@@ -52,7 +56,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -1,6 +1,10 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md
 name: Spell Check
 
+env:
+  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  PYTHON_VERSION: "3.9"
+
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -22,7 +26,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -1,5 +1,11 @@
 name: Test Integration
 
+env:
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: "1.16"
+  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  PYTHON_VERSION: "3.9"
+
 on:
   push:
     paths:
@@ -40,7 +46,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1
@@ -51,7 +57,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -1,5 +1,9 @@
 name: Run tests
 
+env:
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: "1.16"
+
 on:
   push:
     paths:
@@ -36,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -18,9 +18,6 @@ on:
       - "**/*.go"
       - "**/testdata/**"
 
-env:
-  BUILDS_ARTIFACT: build-artifacts
-
 jobs:
   test-go:
     strategy:


### PR DESCRIPTION
Placement of this information at the top of the file, where it is easy to find and edit, facilitates updates to the
workflows as the tool version used for project development are bumped periodically.

This is an established convention in the "template" workflows, but I missed some applications of it. I think it's most
effective when done consistently throughout the workflows.