### PR TITLE
Bump `codecov/codecov-action` workflow dependency to v2

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Send unit tests coverage to Codecov
         if: matrix.operating-system == 'ubuntu-latest'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage_unit.txt
           flags: unit


### PR DESCRIPTION
The `codecov/codecov-action` action is used in the unit test runner workflow to upload code coverage data to codecov. The workflow is configured to use the latest release within the specified major version series. It is necessary to manually update the workflow any time a new major version series of an action begins, in which case a review is necessary to determine whether the workflow is affected by the breaking changes that required the major bump.

The action is now in its 2.x version series. The cause of the major bump was the [removal of some of the action's inputs](https://github.com/codecov/codecov-action/releases/tag/v2.0.0). I reviewed the changes and found that none of the inputs used in the workflow are affected so it is possible to update without any other changes to the workflow.

This pull request supersedes https://github.com/arduino/arduino-lint/pull/230. That was an example of Dependabot attempting to pin the action to a specific minor version rather than our preferred default approach of only pinning the major version ref. The reason is that the specific version tag in the `codecov/codecov-action` repository was created after the major ref tag was moved (Dependabot picks the most recent tag to use as the action ref in its workflow update PRs). Even though it was not possible to use Dependabot's PR in this case, it still served as a helpful notification that a new action version is available.