### PR TITLE
Finish sync of build infrastructure with "template" assets

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -9,6 +9,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
       - "**.go"
   pull_request:
     paths:
@@ -16,6 +17,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
       - "**.go"
   workflow_dispatch:
   repository_dispatch:

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build
         run: |
-          PACKAGE_NAME_PREFIX="${{ github.workflow }}"
+          PACKAGE_NAME_PREFIX="test"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
           fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ vars:
     sh: echo "{{now | date "20060102"}}"
   TAG:
     sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
-  VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}snapshot{{end}}"
+  VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
   CONFIGURATION_PACKAGE: "github.com/arduino/{{.PROJECT_NAME}}/internal/configuration"
   LDFLAGS: >-
     -ldflags

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -10,5 +10,5 @@ sign {
 # Ask Gon for zip output to force notarization process to take place.
 # The CI will ignore the zip output, using the signed binary only.
 zip {
-  output_path = "arduino-lint.zip"
+  output_path = "unused.zip"
 }

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -206,7 +206,7 @@ def test_version(run_command):
     assert result.ok
     output_list = result.stdout.strip().split(sep=" ")
     version = output_list[0]
-    assert semver.VersionInfo.isvalid(version=version) or version == "snapshot" or "nightly" in version
+    assert semver.VersionInfo.isvalid(version=version) or version == "git-snapshot" or "nightly" in version
     dateutil.parser.isoparse(output_list[1])
 
     result = run_command(cmd=["--version", "--format", "json"])
@@ -214,7 +214,7 @@ def test_version(run_command):
     version_output = json.loads(result.stdout)
     if version_output["version"] != "":
         version = version_output["version"]
-        assert semver.VersionInfo.isvalid(version=version) or version == "snapshot" or "nightly" in version
+        assert semver.VersionInfo.isvalid(version=version) or version == "git-snapshot" or "nightly" in version
     assert version_output["commit"] != ""
     dateutil.parser.isoparse(version_output["buildTimestamp"])
 


### PR DESCRIPTION
Some additional changes missed on the first pass (https://github.com/arduino/arduino-lint/pull/222), which are required for a full sync with [the standardized "template" project build assets](https://github.com/arduino/tooling-project-assets/tree/main/workflow-templates).