### PR TITLE
Replace problematic release of `github.com/oleiade/reflections` dependency

### DIFF
--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -5,6 +5,8 @@ go 1.16
 
 replace github.com/arduino/arduino-lint => ../
 
+replace github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1 // https://github.com/oleiade/reflections/issues/14
+
 require (
 	github.com/arduino/arduino-lint v0.0.0
 	github.com/spf13/cobra v1.1.1

--- a/docsgen/go.sum
+++ b/docsgen/go.sum
@@ -751,7 +751,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOWpxbJYzzgUsc=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/oleiade/reflections v1.0.0/go.mod h1:RbATFBbKYkVdqmSFtx13Bb/tVhR0lgOBXunWTZKeL4w=
+github.com/oleiade/reflections v1.0.1/go.mod h1:rdFxbxq4QXVZWj0F+e9jqjDkc7dbp97vkRixKo2JR60=
 github.com/oleksandr/bonjour v0.0.0-20160508152359-5dcf00d8b228/go.mod h1:MGuVJ1+5TX1SCoO2Sx0eAnjpdRytYla2uC1YIZfkC9c=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/arduino/arduino-lint
 
 go 1.16
 
+replace github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1 // https://github.com/oleiade/reflections/issues/14
+
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -749,7 +749,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOWpxbJYzzgUsc=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/oleiade/reflections v1.0.0/go.mod h1:RbATFBbKYkVdqmSFtx13Bb/tVhR0lgOBXunWTZKeL4w=
+github.com/oleiade/reflections v1.0.1/go.mod h1:rdFxbxq4QXVZWj0F+e9jqjDkc7dbp97vkRixKo2JR60=
 github.com/oleksandr/bonjour v0.0.0-20160508152359-5dcf00d8b228/go.mod h1:MGuVJ1+5TX1SCoO2Sx0eAnjpdRytYla2uC1YIZfkC9c=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=


### PR DESCRIPTION
This indirect dependency had a force push that changed the checksum of its v1.0.0 tag 
 (https://github.com/oleiade/reflections/issues/14). This causes Dependabot to fail, meaning it won't provide any notifications of dependency updates (nor is Dependabot so kind as to provide a notification of such failures):
https://github.com/arduino/arduino-lint/network/updates/180623112
> Dependabot can't resolve your Go dependency files
Dependabot failed to update your dependencies because there was an error resolving your Go dependency files.
Dependabot encountered the following error:
verifying github.com/oleiade/reflections@v1.0.0/go.mod: checksum mismatch

There has been a new release of `github.com/oleiade/reflections` and this is slowly working its way up Arduino Lint's supply chain, but it's still not here. So I am forcing a replacement of the module's v1.0.0 tag with the v1.0.1, [which is identical to v1.0.0](https://github.com/oleiade/reflections/compare/v1.0.0...v1.0.1). This change should be reverted once the supply chain provides `github.com/oleiade/reflections@v1.0.1` directly.