### PR TITLE
Don't require Codecov upload success for test run in fork

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -10,6 +10,7 @@ on:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -61,4 +61,4 @@ jobs:
         with:
           file: ./coverage_unit.txt
           flags: unit
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.repository == 'arduino/arduino-lint' }}


### PR DESCRIPTION
The "Test Go" workflow uploads code coverage data to Codecov. There will occasionally be spurious upload failures caused by transient network outages. These will typically succeed after the workflow is re-run, but the option to re-run is not offered when the workflow run passes.

Because it's important that the data be complete, [the `codecov/codecov-action` action](https://github.com/codecov/codecov-action) is configured to fail the workflow run if the upload does not succeed. However, the upload will never be able to succeed for workflow runs in a fork where the owner has not set up Codecov. For this reason, [the `fail_ci_if_error` input](https://github.com/codecov/codecov-action#arguments) setting is made conditional upon [the repository name](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context).

The result is:

- Coverage data upload success is required for all workflow runs in the `arduino/arduino-lint` repository, including those for PRs  submitted from forks (this data is uploaded to the parent repo's Codecov account, so the upload is able to succeed regardless of whether Codecov is enabled for the fork).
- Uploads are attempted for workflow runs in forks (because the fork owner might have Codecov set up and want the data), but they are not required to succeed and will fail silently.