### PR TITLE
Use standard version of Go in "Check Website" workflow

### DIFF
--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -3,7 +3,7 @@ name: Check Website
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 


### PR DESCRIPTION
Go 1.16 is now used for all development of this project (https://github.com/arduino/arduino-lint/pull/222/commits/86692a21368a93353e190ef4ada29640338b8baf). This is the last remaining component of the project infrastructure left specifiying Go 1.14.