### PR TITLE
Run relevant workflows on release branch creation

### DIFF
--- a/.github/workflows/check-code-generation-task.yml
+++ b/.github/workflows/check-code-generation-task.yml
@@ -5,6 +5,7 @@ env:
   GO_VERSION: "1.16"
 
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-code-generation-task.ya?ml"
@@ -23,7 +24,32 @@ on:
       - "etc/schemas/**/*.json"
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
@@ -25,7 +26,32 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check-errors:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -47,6 +73,8 @@ jobs:
         run: task go:vet
 
   check-outdated:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -71,6 +99,8 @@ jobs:
         run: git diff --color --exit-code
 
   check-style:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -95,6 +125,8 @@ jobs:
         run: task --silent go:lint
 
   check-formatting:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -120,6 +152,8 @@ jobs:
 
   check-config:
     name: check-config (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -3,6 +3,7 @@ name: Publish Tester Build
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/publish-go-tester-task.ya?ml"
@@ -28,7 +29,32 @@ env:
   BUILDS_ARTIFACT: build-artifacts
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   build:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -9,6 +9,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-integration-task.ya?ml"
@@ -33,7 +34,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+
     strategy:
       matrix:
         operating-system:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
@@ -29,7 +30,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+
     strategy:
       matrix:
         operating-system:


### PR DESCRIPTION
The [trunk-based development](https://trunkbaseddevelopment.com/) strategy is used by this project. The release branch may contain a subset of the history of the default branch.

The status of the GitHub Actions workflows should be evaluated before making a release. However, this is not so simple as checking the status of the commit at the tip of the release branch. The reason is that, for the sake of efficiency, the [workflows are configured](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on) to run only when the processes are relevant to the trigger event (e.g., no need to run unit tests for a change to the readme).

In the case of the default branch, you can simply [set the workflow runs filter to that branch](https://github.com/arduino/arduino-lint/actions?query=branch%3Amain) and then check the result of the latest run of each workflow of interest. However, that was not possible to do with the release branch since it might be that the workflow was never run in that branch. The status of the latest run of the workflow in the default branch might not match the status for the release branch if the release branch does not contain the full history.

For this reason, it will be helpful to trigger all relevant workflows on the creation of a release branch. This will ensure that each of those workflows will always have at least one run in the release branch. Subsequent commits pushed to the branch can trigger workflows based on their usual filters and the status of the latest run of each workflow in the branch will provide an accurate indication of the state of that branch.

Branches are created for purposes other than releases, most notably feature branches to stage work for a pull request. Because the collection of workflows are very comprehensive, it would not be convenient or efficient to run them on the creation of every feature branch.

Unfortunately, GitHub Actions does not support filters on [the `create` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#create) generated by branch creation like it does for the `push` and `pull_request` events. There is support for a [`branches` filter](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags) of the `push` event, but that filter is an AND to the `paths` filter and this application requires an OR. For this reason, the workflows must be triggered by the creation of every branch. The unwanted job runs are prevented by adding a `run-determination` job with the branch filter handled by Bash commands. The other jobs of the workflow use this `run-determination` [job as a dependency](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds), only running when it indicates they should via a [job output](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs). Because this minimal `run-determination` job runs very quickly, it is roughly equivalent to the workflow having been skipped entirely for non-release branch creations. This approach has been in use for some time already in the "Deploy Website" workflow.