### PR TITLE
Panic on unexpected schema validation error

### DIFF
--- a/internal/rule/schema/schema.go
+++ b/internal/rule/schema/schema.go
@@ -81,11 +81,19 @@ func Compile(schemaFilename string, referencedSchemaFilenames []string, dataLoad
 // jsonschema.ValidationError object otherwise.
 func Validate(instanceInterface map[string]interface{}, schemaObject Schema) ValidationResult {
 	validationError := schemaObject.Compiled.ValidateInterface(instanceInterface)
-	result, _ := validationError.(*jsonschema.ValidationError)
 	validationResult := ValidationResult{
-		Result:     result,
+		Result:     nil,
 		dataLoader: schemaObject.dataLoader,
 	}
+
+	if validationError != nil {
+		result, ok := validationError.(*jsonschema.ValidationError)
+		if !ok {
+			panic(validationError)
+		}
+		validationResult.Result = result
+	}
+
 	if validationResult.Result == nil {
 		logrus.Debug("Schema validation of instance document passed")
 	} else {


### PR DESCRIPTION
The `err` return value of `*jsonschema.Schema.ValidateInterface()` is used to pass the schema validation failure result.
That error type is given special treatment by Arduino Lint because it occurs under normal circumstances when a rule
violation occurs, and must be interpreted by the rule functions, or even ignored, depending on the tool configuration.

The `err` return value of `*jsonschema.Schema.ValidateInterface()` is also used to return errors that indicate some
unexpected problem has occurred separate from a schema validation failure. Previously, these other error types were
ignored and the validation treated as if it had passed, even though it likely never even ran.

Since Arduino Lint controls both the instance and schema data, such these true errors returned by the validation process
should not ever occur when the application is operating correctly. For this reason, a panic is triggered immediately.