### PR TITLE
Fix properties mapping utility function handling of overlapping keys

### DIFF
--- a/internal/project/general/general.go
+++ b/internal/project/general/general.go
@@ -32,20 +32,19 @@ In the event a full recursion of key levels is desired, set the levels argument 
 func PropertiesToMap(flatProperties *properties.Map, levels int) map[string]interface{} {
 	propertiesInterface := make(map[string]interface{})
 
-	var keys []string
 	if levels != 1 {
-		keys = flatProperties.FirstLevelKeys()
+		for _, key := range flatProperties.FirstLevelKeys() {
+			subTree := flatProperties.SubTree(key)
+			if subTree.Size() > 0 {
+				// This key contains a map.
+				propertiesInterface[key] = PropertiesToMap(subTree, levels-1)
+			} else {
+				// This key contains a string, no more recursion is possible.
+				propertiesInterface[key] = flatProperties.Get(key)
+			}
+		}
 	} else {
-		keys = flatProperties.Keys()
-	}
-
-	for _, key := range keys {
-		subTree := flatProperties.SubTree(key)
-		if subTree.Size() > 0 {
-			// This key contains a map.
-			propertiesInterface[key] = PropertiesToMap(subTree, levels-1)
-		} else {
-			// This key contains a string, no more recursion is possible.
+		for _, key := range flatProperties.Keys() {
 			propertiesInterface[key] = flatProperties.Get(key)
 		}
 	}

--- a/internal/project/general/general_test.go
+++ b/internal/project/general/general_test.go
@@ -31,6 +31,10 @@ func TestPropertiesToMap(t *testing.T) {
 		foo.bar=asdf
 		foo.baz=zxcv
 		bar.bat.bam=123
+		qux.a=x
+		qux.a.b=y
+		fuz.a.b=y
+		fuz.a=x
 	`)
 	propertiesInput, err := properties.LoadFromBytes(rawProperties)
 	require.Nil(t, err)
@@ -41,6 +45,10 @@ func TestPropertiesToMap(t *testing.T) {
 		"foo.bar":     "asdf",
 		"foo.baz":     "zxcv",
 		"bar.bat.bam": "123",
+		"qux.a":       "x",
+		"qux.a.b":     "y",
+		"fuz.a.b":     "y",
+		"fuz.a":       "x",
 	}
 
 	assert.True(t, reflect.DeepEqual(expectedMapOutput, PropertiesToMap(propertiesInput, 1)))
@@ -54,6 +62,14 @@ func TestPropertiesToMap(t *testing.T) {
 		},
 		"bar": map[string]interface{}{
 			"bat.bam": "123",
+		},
+		"qux": map[string]interface{}{
+			"a":   "x",
+			"a.b": "y",
+		},
+		"fuz": map[string]interface{}{
+			"a.b": "y",
+			"a":   "x",
 		},
 	}
 
@@ -69,6 +85,16 @@ func TestPropertiesToMap(t *testing.T) {
 		"bar": map[string]interface{}{
 			"bat": map[string]interface{}{
 				"bam": "123",
+			},
+		},
+		"qux": map[string]interface{}{
+			"a": map[string]interface{}{
+				"b": "y", // It is impossible to represent the complete "properties" data structure recursed to this depth.
+			},
+		},
+		"fuz": map[string]interface{}{
+			"a": map[string]interface{}{
+				"b": "y",
 			},
 		},
 	}


### PR DESCRIPTION
The Arduino project configuration fields have an odd usage of the `properties.Map` format. Dots may sometimes indicate nested keys, but in other cases they are merely a character in the key string. Previously, the utility function used to recursively map to a configurable depth was not correctly handling this situation due to using the same code both for the recursive mapping to subkeys as well as for the flat mapping at the final depth. The fix for the bug also makes the function more efficient by avoiding calling `SubTree()` when it's already known there is no subtree.