### PR TITLE
Sync project assets from the standardized "template" versions

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ot,propert
+skip = ./.git,**/go.mod,**/go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./arduino-lint,./arduino-lint.exe,./internal/rule/rulefunction/testdata/libraries/MisspelledSentenceParagraphValue/library.properties,./site
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =
-skip = ./.git,**/go.mod,**/go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./arduino-lint,./arduino-lint.exe,./internal/rule/rulefunction/testdata/libraries/MisspelledSentenceParagraphValue/library.properties,./site

--- a/.ecrc
+++ b/.ecrc
@@ -1,7 +1,7 @@
 {
   "Exclude": [
-    "LICENSE.txt",
-    "poetry.lock",
+    "^LICENSE\\.txt$",
+    "^poetry\\.lock$",
     "^internal/rule/schema/schemadata/bindata.go$",
     "^internal/rule/schema/testdata/bindata.go$"
   ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -56,5 +56,5 @@ indent_style = space
 indent_size = 2
 indent_style = space
 
-[.gitmodules]
+[{.gitconfig,.gitmodules}]
 indent_style = tab

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -103,10 +103,14 @@ jobs:
           chmod +x "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}"
           PACKAGE_FILENAME="$(basename ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_nightly-*_macOS_64bit.tar.gz)"
           tar -czvf "${{ env.DIST_DIR }}/$PACKAGE_FILENAME" \
-          -C "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/" "${{ env.PROJECT_NAME }}" \
-          -C ../../ LICENSE.txt
+            -C "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/" "${{ env.PROJECT_NAME }}" \
+            -C ../../ LICENSE.txt
           CHECKSUM="$(shasum -a 256 ${{ env.DIST_DIR }}/$PACKAGE_FILENAME | cut -d " " -f 1)"
-          perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM} ${PACKAGE_FILENAME}/g;" ${{ env.DIST_DIR }}/*-checksums.txt
+          perl \
+            -pi \
+            -w \
+            -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM} ${PACKAGE_FILENAME}/g;" \
+            ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -60,8 +60,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -108,10 +108,14 @@ jobs:
           chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
           TAG="${GITHUB_REF/refs\/tags\//}"
           tar -czvf "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
-          -C ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/  ${{ env.PROJECT_NAME }}   \
-          -C ../../ LICENSE.txt
+            -C ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/ ${{ env.PROJECT_NAME }} \
+            -C ../../ LICENSE.txt
           CHECKSUM="$(shasum -a 256 ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)"
-          perl -pi -w -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" ${{ env.DIST_DIR }}/*-checksums.txt
+          perl \
+            -pi \
+            -w \
+            -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" \
+            ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -129,9 +129,6 @@ jobs:
     needs: notarize-macos
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -151,6 +151,8 @@ jobs:
           bodyFile: ${{ env.DIST_DIR }}/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+          # NOTE: "Artifact is a directory" warnings are expected and don't indicate a problem
+          # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
       - name: Upload release files on Arduino downloads servers

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,6 +39,8 @@ vars:
     -X {{.CONFIGURATION_PACKAGE}}.Commit={{.COMMIT}}
     -X {{.CONFIGURATION_PACKAGE}}.Timestamp={{.TIMESTAMP}}
     '
+  # `-ldflags` flag to use for `go test` command
+  TEST_LDFLAGS:
 
 tasks:
   build:
@@ -225,6 +227,7 @@ tasks:
           -run '{{default ".*" .GO_TEST_REGEX}}' \
           {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} \
           -coverprofile=coverage_unit.txt \
+          {{.TEST_LDFLAGS}} \
           {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-integration-task/Taskfile.yml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -109,6 +109,7 @@ tasks:
     deps:
       - task: go:cli-docs
       - task: go:rule-docs
+    cmds:
       # Make the formatting consistent with the non-generated Markdown
       - task: general:format-prettier
 


### PR DESCRIPTION
We have assembled a collection of reusable project assets:
https://github.com/arduino/tooling-project-assets
These are used in the repositories of all Arduino tooling projects.

Some minor fixes, improvements, and standardizations have been made in the upstream "template" assets, and those are introduced to this repository via this pull request.
