### PR TITLE
Allow use of code under later versions of GPL

### DIFF
--- a/etc/schemas/arduino-boards-txt-definitions-schema.json
+++ b/etc/schemas/arduino-boards-txt-definitions-schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-definitions-schema.json",
   "title": "Shared definitions for the Arduino boards.txt schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "propertiesObjects": {
       "menu": {

--- a/etc/schemas/arduino-boards-txt-permissive-schema.json
+++ b/etc/schemas/arduino-boards-txt-permissive-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-permissive-schema.json",
   "title": "Arduino boards.txt JSON permissive schema",
   "description": "boards.txt contains the boards definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#boardstxt",
-  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "menu": {

--- a/etc/schemas/arduino-boards-txt-schema.json
+++ b/etc/schemas/arduino-boards-txt-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-schema.json",
   "title": "Arduino boards.txt JSON schema",
   "description": "boards.txt contains the boards definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#boardstxt",
-  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "menu": {

--- a/etc/schemas/arduino-boards-txt-strict-schema.json
+++ b/etc/schemas/arduino-boards-txt-strict-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-strict-schema.json",
   "title": "Arduino boards.txt JSON strict schema",
   "description": "boards.txt contains the boards definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#boardstxt",
-  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "menu": {

--- a/etc/schemas/arduino-library-properties-definitions-schema.json
+++ b/etc/schemas/arduino-library-properties-definitions-schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-definitions-schema.json",
   "title": "Shared definitions for the Arduino library.properties schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "definitions": {
     "general": {

--- a/etc/schemas/arduino-library-properties-permissive-schema.json
+++ b/etc/schemas/arduino-library-properties-permissive-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-permissive-schema.json",
   "title": "Arduino library.properties JSON permissive schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the minimum requirements for this file. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
-  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {

--- a/etc/schemas/arduino-library-properties-schema.json
+++ b/etc/schemas/arduino-library-properties-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-schema.json",
   "title": "Arduino library.properties JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
-  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {

--- a/etc/schemas/arduino-library-properties-strict-schema.json
+++ b/etc/schemas/arduino-library-properties-strict-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-strict-schema.json",
   "title": "Arduino library.properties strict JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the recommended format. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
-  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {

--- a/etc/schemas/arduino-package-index-definitions-schema.json
+++ b/etc/schemas/arduino-package-index-definitions-schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-definitions-schema.json",
   "title": "Shared definitions for the Arduino Package Index schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "root": {
       "base": {

--- a/etc/schemas/arduino-package-index-permissive-schema.json
+++ b/etc/schemas/arduino-package-index-permissive-schema.json
@@ -3,6 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-permissive-schema.json",
   "title": "Arduino Package Index JSON permissive schema",
   "description": "Package indexes define Arduino hardware packages. See: https://arduino.github.io/arduino-cli/latest/package_index_json-specification/. This schema defines the minimum accepted data format.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "allOf": [
     {
       "$ref": "arduino-package-index-definitions-schema.json#/definitions/root/permissive/object"

--- a/etc/schemas/arduino-package-index-schema.json
+++ b/etc/schemas/arduino-package-index-schema.json
@@ -3,6 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-schema.json",
   "title": "Arduino Package Index JSON schema",
   "description": "Package indexes define Arduino hardware packages. See: https://arduino.github.io/arduino-cli/latest/package_index_json-specification/. This schema defines the data format per the specification.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "allOf": [
     {
       "$ref": "arduino-package-index-definitions-schema.json#/definitions/root/specification/object"

--- a/etc/schemas/arduino-package-index-strict-schema.json
+++ b/etc/schemas/arduino-package-index-strict-schema.json
@@ -3,6 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-strict-schema.json",
   "title": "Arduino Package Index JSON strict schema",
   "description": "Package indexes define Arduino hardware packages. See: https://arduino.github.io/arduino-cli/latest/package_index_json-specification/. This schema defines the best practices for the data format, above and beyond the specification.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "allOf": [
     {
       "$ref": "arduino-package-index-definitions-schema.json#/definitions/root/strict/object"

--- a/etc/schemas/arduino-platform-txt-definitions-schema.json
+++ b/etc/schemas/arduino-platform-txt-definitions-schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-definitions-schema.json",
   "title": "Shared definitions for the Arduino platform.txt schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "propertiesObjects": {
       "name": {

--- a/etc/schemas/arduino-platform-txt-permissive-schema.json
+++ b/etc/schemas/arduino-platform-txt-permissive-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-permissive-schema.json",
   "title": "Arduino platform.txt JSON permissive schema",
   "description": "platform.txt contains the platform definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#platformtxt",
-  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {

--- a/etc/schemas/arduino-platform-txt-schema.json
+++ b/etc/schemas/arduino-platform-txt-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-schema.json",
   "title": "Arduino platform.txt JSON schema",
   "description": "platform.txt contains the platform definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#platformtxt",
-  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {

--- a/etc/schemas/arduino-platform-txt-strict-schema.json
+++ b/etc/schemas/arduino-platform-txt-strict-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-strict-schema.json",
   "title": "Arduino platform.txt JSON strict schema",
   "description": "platform.txt contains the platform definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#platformtxt",
-  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {

--- a/etc/schemas/arduino-programmers-txt-definitions-schema.json
+++ b/etc/schemas/arduino-programmers-txt-definitions-schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-definitions-schema.json",
   "title": "Shared definitions for the Arduino programmers.txt schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "propertiesObjects": {
       "programmerID": {

--- a/etc/schemas/arduino-programmers-txt-permissive-schema.json
+++ b/etc/schemas/arduino-programmers-txt-permissive-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-permissive-schema.json",
   "title": "Arduino programmers.txt JSON permissive schema",
   "description": "programmers.txt contains the definitions of Arduino hardware programmers. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#programmerstxt",
-  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "patternProperties": {
     ".+": {

--- a/etc/schemas/arduino-programmers-txt-schema.json
+++ b/etc/schemas/arduino-programmers-txt-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-schema.json",
   "title": "Arduino programmers.txt JSON schema",
   "description": "programmers.txt contains the definitions of Arduino hardware programmers. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#programmerstxt",
-  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "patternProperties": {
     ".+": {

--- a/etc/schemas/arduino-programmers-txt-strict-schema.json
+++ b/etc/schemas/arduino-programmers-txt-strict-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-strict-schema.json",
   "title": "Arduino programmers.txt JSON strict schema",
   "description": "programmers.txt contains the definitions of Arduino hardware programmers. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#programmerstxt",
-  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "patternProperties": {
     ".+": {

--- a/etc/schemas/general-definitions-schema.json
+++ b/etc/schemas/general-definitions-schema.json
@@ -3,6 +3,7 @@
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/general-definitions-schema.json",
   "title": "Shared definitions",
   "description": "Definitions for use in schemas.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "definitions": {
     "patternObjects": {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/defaults.go
+++ b/internal/configuration/defaults.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/rulemode/rulemode.go
+++ b/internal/configuration/rulemode/rulemode.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/configuration/rulemode/rulemode_test.go
+++ b/internal/configuration/rulemode/rulemode_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/general/general.go
+++ b/internal/project/general/general.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/general/general_test.go
+++ b/internal/project/general/general_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/library.go
+++ b/internal/project/library/library.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/library_test.go
+++ b/internal/project/library/library_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/libraryproperties/libraryproperties.go
+++ b/internal/project/library/libraryproperties/libraryproperties.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/library/libraryproperties/librarypropertiesschemas_test.go
+++ b/internal/project/library/libraryproperties/librarypropertiesschemas_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/packageindex/packageindex.go
+++ b/internal/project/packageindex/packageindex.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/packageindex/packageindex_test.go
+++ b/internal/project/packageindex/packageindex_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/packageindex/packageindexschemas_test.go
+++ b/internal/project/packageindex/packageindexschemas_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/boardstxt/boardstxt.go
+++ b/internal/project/platform/boardstxt/boardstxt.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/boardstxt/boardstxt_test.go
+++ b/internal/project/platform/boardstxt/boardstxt_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/boardstxt/boardstxtschema_test.go
+++ b/internal/project/platform/boardstxt/boardstxtschema_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platform.go
+++ b/internal/project/platform/platform.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platform_test.go
+++ b/internal/project/platform/platform_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platformtxt/platformtxt.go
+++ b/internal/project/platform/platformtxt/platformtxt.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platformtxt/platformtxt_test.go
+++ b/internal/project/platform/platformtxt/platformtxt_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/platformtxt/platformtxtschema_test.go
+++ b/internal/project/platform/platformtxt/platformtxtschema_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/programmerstxt/programmerstxt.go
+++ b/internal/project/platform/programmerstxt/programmerstxt.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/programmerstxt/programmerstxt_test.go
+++ b/internal/project/platform/programmerstxt/programmerstxt_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/platform/programmerstxt/programmerstxtschema_test.go
+++ b/internal/project/platform/programmerstxt/programmerstxtschema_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/library.go
+++ b/internal/project/projectdata/library.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/packageindex.go
+++ b/internal/project/projectdata/packageindex.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/platform.go
+++ b/internal/project/projectdata/platform.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/platform_test.go
+++ b/internal/project/projectdata/platform_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/projectdata.go
+++ b/internal/project/projectdata/projectdata.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projectdata/sketch.go
+++ b/internal/project/projectdata/sketch.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projecttype/projecttype.go
+++ b/internal/project/projecttype/projecttype.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/projecttype/projecttype_test.go
+++ b/internal/project/projecttype/projecttype_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/sketch/sketch.go
+++ b/internal/project/sketch/sketch.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/project/sketch/sketch_test.go
+++ b/internal/project/sketch/sketch_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/feedback/feedback.go
+++ b/internal/result/feedback/feedback.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/outputformat/outputformat.go
+++ b/internal/result/outputformat/outputformat.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/outputformat/outputformat_test.go
+++ b/internal/result/outputformat/outputformat_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/result.go
+++ b/internal/result/result.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/result/result_test.go
+++ b/internal/result/result_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/ruleconfiguration/ruleconfiguration.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/ruleconfiguration/ruleconfiguration_test.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/library.go
+++ b/internal/rule/rulefunction/library.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/library_test.go
+++ b/internal/rule/rulefunction/library_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/packageindex.go
+++ b/internal/rule/rulefunction/packageindex.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/packageindex_test.go
+++ b/internal/rule/rulefunction/packageindex_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/platform.go
+++ b/internal/rule/rulefunction/platform.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/platform_test.go
+++ b/internal/rule/rulefunction/platform_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/rulefunction.go
+++ b/internal/rule/rulefunction/rulefunction.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/rulefunction_test.go
+++ b/internal/rule/rulefunction/rulefunction_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/sketch.go
+++ b/internal/rule/rulefunction/sketch.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulefunction/sketch_test.go
+++ b/internal/rule/rulefunction/sketch_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulelevel/rulelevel.go
+++ b/internal/rule/rulelevel/rulelevel.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/rulelevel/rulelevel_test.go
+++ b/internal/rule/rulelevel/rulelevel_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/ruleresult/ruleresult.go
+++ b/internal/rule/ruleresult/ruleresult.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/compliancelevel/compliancelevel.go
+++ b/internal/rule/schema/compliancelevel/compliancelevel.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/parsevalidationresult.go
+++ b/internal/rule/schema/parsevalidationresult.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/schema.go
+++ b/internal/rule/schema/schema.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/schema_test.go
+++ b/internal/rule/schema/schema_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/internal/rule/schema/schemadata/bindata.go
+++ b/internal/rule/schema/schemadata/bindata.go
@@ -77,6 +77,7 @@ var _arduinoBoardsTxtDefinitionsSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-definitions-schema.json",
   "title": "Shared definitions for the Arduino boards.txt schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "propertiesObjects": {
       "menu": {
@@ -1315,7 +1316,7 @@ var _arduinoBoardsTxtPermissiveSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-permissive-schema.json",
   "title": "Arduino boards.txt JSON permissive schema",
   "description": "boards.txt contains the boards definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#boardstxt",
-  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "menu": {
@@ -1350,7 +1351,7 @@ var _arduinoBoardsTxtSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-schema.json",
   "title": "Arduino boards.txt JSON schema",
   "description": "boards.txt contains the boards definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#boardstxt",
-  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "menu": {
@@ -1385,7 +1386,7 @@ var _arduinoBoardsTxtStrictSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-boards-txt-strict-schema.json",
   "title": "Arduino boards.txt JSON strict schema",
   "description": "boards.txt contains the boards definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#boardstxt",
-  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the boards.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "menu": {
@@ -1419,6 +1420,7 @@ var _arduinoLibraryPropertiesDefinitionsSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-definitions-schema.json",
   "title": "Shared definitions for the Arduino library.properties schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "definitions": {
     "general": {
@@ -2293,7 +2295,7 @@ var _arduinoLibraryPropertiesPermissiveSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-permissive-schema.json",
   "title": "Arduino library.properties JSON permissive schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the minimum requirements for this file. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
-  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {
@@ -2373,7 +2375,7 @@ var _arduinoLibraryPropertiesSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-schema.json",
   "title": "Arduino library.properties JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
-  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {
@@ -2453,7 +2455,7 @@ var _arduinoLibraryPropertiesStrictSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-library-properties-strict-schema.json",
   "title": "Arduino library.properties strict JSON schema",
   "description": "library.properties is the metadata file for Arduino libraries. This schema defines the recommended format. See: https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata",
-  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the Arduino library.properties format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {
@@ -2532,6 +2534,7 @@ var _arduinoPackageIndexDefinitionsSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-definitions-schema.json",
   "title": "Shared definitions for the Arduino Package Index schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "root": {
       "base": {
@@ -3994,6 +3997,7 @@ var _arduinoPackageIndexPermissiveSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-permissive-schema.json",
   "title": "Arduino Package Index JSON permissive schema",
   "description": "Package indexes define Arduino hardware packages. See: https://arduino.github.io/arduino-cli/latest/package_index_json-specification/. This schema defines the minimum accepted data format.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "allOf": [
     {
       "$ref": "arduino-package-index-definitions-schema.json#/definitions/root/permissive/object"
@@ -4022,6 +4026,7 @@ var _arduinoPackageIndexSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-schema.json",
   "title": "Arduino Package Index JSON schema",
   "description": "Package indexes define Arduino hardware packages. See: https://arduino.github.io/arduino-cli/latest/package_index_json-specification/. This schema defines the data format per the specification.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "allOf": [
     {
       "$ref": "arduino-package-index-definitions-schema.json#/definitions/root/specification/object"
@@ -4050,6 +4055,7 @@ var _arduinoPackageIndexStrictSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-package-index-strict-schema.json",
   "title": "Arduino Package Index JSON strict schema",
   "description": "Package indexes define Arduino hardware packages. See: https://arduino.github.io/arduino-cli/latest/package_index_json-specification/. This schema defines the best practices for the data format, above and beyond the specification.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "allOf": [
     {
       "$ref": "arduino-package-index-definitions-schema.json#/definitions/root/strict/object"
@@ -4077,6 +4083,7 @@ var _arduinoPlatformTxtDefinitionsSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-definitions-schema.json",
   "title": "Shared definitions for the Arduino platform.txt schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "propertiesObjects": {
       "name": {
@@ -5887,7 +5894,7 @@ var _arduinoPlatformTxtPermissiveSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-permissive-schema.json",
   "title": "Arduino platform.txt JSON permissive schema",
   "description": "platform.txt contains the platform definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#platformtxt",
-  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {
@@ -5976,7 +5983,7 @@ var _arduinoPlatformTxtSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-schema.json",
   "title": "Arduino platform.txt JSON schema",
   "description": "platform.txt contains the platform definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#platformtxt",
-  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {
@@ -6065,7 +6072,7 @@ var _arduinoPlatformTxtStrictSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-platform-txt-strict-schema.json",
   "title": "Arduino platform.txt JSON strict schema",
   "description": "platform.txt contains the platform definitions of Arduino platforms. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#platformtxt",
-  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the platform.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "properties": {
     "name": {
@@ -6153,6 +6160,7 @@ var _arduinoProgrammersTxtDefinitionsSchemaJson = []byte(`{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-definitions-schema.json",
   "title": "Shared definitions for the Arduino programmers.txt schemas",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "definitions": {
     "propertiesObjects": {
       "programmerID": {
@@ -6379,7 +6387,7 @@ var _arduinoProgrammersTxtPermissiveSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-permissive-schema.json",
   "title": "Arduino programmers.txt JSON permissive schema",
   "description": "programmers.txt contains the definitions of Arduino hardware programmers. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#programmerstxt",
-  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "patternProperties": {
     ".+": {
@@ -6409,7 +6417,7 @@ var _arduinoProgrammersTxtSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-schema.json",
   "title": "Arduino programmers.txt JSON schema",
   "description": "programmers.txt contains the definitions of Arduino hardware programmers. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#programmerstxt",
-  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "patternProperties": {
     ".+": {
@@ -6439,7 +6447,7 @@ var _arduinoProgrammersTxtStrictSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/arduino-programmers-txt-strict-schema.json",
   "title": "Arduino programmers.txt JSON strict schema",
   "description": "programmers.txt contains the definitions of Arduino hardware programmers. See: https://arduino.github.io/arduino-cli/latest/platform-specification/#programmerstxt",
-  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap",
+  "$comment": "For information on the programmers.txt format, see https://godoc.org/github.com/arduino/go-properties-orderedmap. This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "patternProperties": {
     ".+": {
@@ -6469,6 +6477,7 @@ var _generalDefinitionsSchemaJson = []byte(`{
   "$id": "https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/schemas/general-definitions-schema.json",
   "title": "Shared definitions",
   "description": "Definitions for use in schemas.",
+  "$comment": "This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
   "type": "object",
   "definitions": {
     "patternObjects": {

--- a/internal/util/test/test.go
+++ b/internal/util/test/test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/main.go
+++ b/main.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //

--- a/ruledocsgen/main.go
+++ b/ruledocsgen/main.go
@@ -1,3 +1,19 @@
+// This file is part of Arduino Lint.
+//
+// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
 // Package main generates Markdown documentation for Arduino Lint's rules.
 package main
 

--- a/ruledocsgen/main_test.go
+++ b/ruledocsgen/main_test.go
@@ -2,8 +2,9 @@
 //
 // Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3,
-// which covers the main part of Arduino Lint.
+// This software is released under the GNU General Public License, either
+// version 3 of the License, or (at your option) any later version.
+// This license covers the main part of Arduino Lint.
 // The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //


### PR DESCRIPTION
The license type of Arduino Lint is hereby changed from "[GPL-3.0-only](https://spdx.org/licenses/GPL-3.0-only.html)" to "[GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html)", for the reason explained here:

https://www.gnu.org/licenses/gpl-faq.html#VersionThreeOrLater

Arduino Lint's GPL 3.0 license itself provides for either type, but the "or later" exception is only available if it is
explicitly stated:

> If the Program specifies that a certain numbered version of the GNU General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.

This was not previously done in the Arduino Lint code base, meaning that it could not be used by code licensed under some later version of GPL.

The previous use of the "GPL-3.0-only" license type was not a conscious decision, but simply the result of copy/pasting the license header from another project which happened to be "GPL-3.0-only". I simply copy/pasted the license from Arduino CLI, which is also "GPL-3.0-only".

Since Arduino has complete ownership of all code subject to this change, no external permission must be obtained to make this change.