### PR TITLE
Fix errors in package index project data unit tests for `discoveryDependencies`

### DIFF
--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -740,6 +740,14 @@ func TestInitializeForPackageIndex(t *testing.T) {
 			}
 		}
 
+		testTable.packageIndexDiscoveryDependenciesAssertion(t, PackageIndexDiscoveryDependencies(), testTable.testName)
+		if PackageIndexDiscoveryDependencies() != nil {
+			for index, packageIndexDiscoveryDependency := range PackageIndexDiscoveryDependencies() {
+				assert.Equal(t, testTable.packageIndexDiscoveryDependenciesDataAssertion[index].ID, packageIndexDiscoveryDependency.ID, testTable.testName)
+				assert.Equal(t, testTable.packageIndexDiscoveryDependenciesDataAssertion[index].JSONPointer, packageIndexDiscoveryDependency.JSONPointer, testTable.testName)
+			}
+		}
+
 		testTable.packageIndexToolsAssertion(t, PackageIndexTools(), testTable.testName)
 		if PackageIndexTools() != nil {
 			for index, packageIndexTool := range PackageIndexTools() {

--- a/internal/project/projectdata/packageindex_test.go
+++ b/internal/project/projectdata/packageindex_test.go
@@ -397,7 +397,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 				},
 				{
 					ID:          "foopackager2:megaavr@1.0.0 >> quxpackager:sneakernet-discovery",
-					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/3",
+					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/2",
 				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,
@@ -618,7 +618,7 @@ func TestInitializeForPackageIndex(t *testing.T) {
 				},
 				{
 					ID:          "foopackager2:megaavr@1.0.0 >> quxpackager:sneakernet-discovery",
-					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/3",
+					JSONPointer: "/packages/1/platforms/2/discoveryDependencies/2",
 				},
 			},
 			packageIndexToolsAssertion: assert.NotNil,


### PR DESCRIPTION
In preparation for linting a project, Arduino Lint collects information that may be needed by multiple rules, referred to as "project data".

For [package index](https://arduino.github.io/arduino-cli/dev/package_index_json-specification/) projects, this data includes the contents of the `packages[].platforms[].discoveryDependencies[]` field, stored in a slice along with identifiers.

At the time the code was added for collecting that project data, new assertions were added to the unit test tables to cover it, but the test table handling code was not updated, meaning the assertions were never tested.

This PR adds that missing test table handling code and also fixes some errors in the assertions that were revealed by testing them.