### PR TITLE
Use Dependabot to maintain dependencies of the ruledocsgen module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+  - package-ecosystem: gomod
+    directory: /ruledocsgen/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
 
   - package-ecosystem: pip
     directory: /


### PR DESCRIPTION
The repository contains three Go modules:

- `github.com/arduino/arduino-lint` - in the repository root
- `github.com/arduino/arduino-lint/docsgen` -  in `docsgen/`
- `github.com/arduino/arduino-lint/ruledocsgen` -  in `ruledocsgen/`

Dependabot has been configured to submit PRs for updates of the first two modules, but the Dependabot configuration was
not updated at the time the `github.com/arduino/arduino-lint/ruledocsgen` module was added, so it is not receiving that
important service.