### PR TITLE
Fix install script's check for previous installation

### DIFF
--- a/etc/install.sh
+++ b/etc/install.sh
@@ -186,8 +186,7 @@ bye() {
 
 testVersion() {
   set +e
-  EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"
-  if [ "$?" = "0" ]; then
+  if EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"; then
     # Convert to resolved, absolute paths before comparison
     EXECUTABLE_REALPATH="$(cd -- "$(dirname -- "$EXECUTABLE_PATH")" && pwd -P)"
     EFFECTIVE_BINDIR_REALPATH="$(cd -- "$EFFECTIVE_BINDIR" && pwd -P)"

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -187,18 +187,19 @@ bye() {
 testVersion() {
   set +e
   EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"
-  if [ "$?" = "1" ]; then
-    # $PATH is intentionally a literal in this message.
-    # shellcheck disable=SC2016
-    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
-  else
+  if [ "$?" = "0" ]; then
     # Convert to resolved, absolute paths before comparison
     EXECUTABLE_REALPATH="$(cd -- "$(dirname -- "$EXECUTABLE_PATH")" && pwd -P)"
     EFFECTIVE_BINDIR_REALPATH="$(cd -- "$EFFECTIVE_BINDIR" && pwd -P)"
     if [ "$EXECUTABLE_REALPATH" != "$EFFECTIVE_BINDIR_REALPATH" ]; then
+      # $PATH is intentionally a literal in this message.
       # shellcheck disable=SC2016
       echo "An existing $PROJECT_NAME was found at $EXECUTABLE_PATH. Please prepend \"$EFFECTIVE_BINDIR\" to your "'$PATH'" or remove the existing one."
     fi
+  else
+    # $PATH is intentionally a literal in this message.
+    # shellcheck disable=SC2016
+    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
   fi
 
   set -e


### PR DESCRIPTION
The installation script checks for an existing installation in the `PATH` in order to provide appropriate advice to the user about adding the installation to their their `PATH` environment variable.

This check is done using `command -v`. It turns out that the exit status is shell dependent in the event the command is not found, so that it might be either `1` or `127` depending on the user's system. The script previously assumed that the exit status would be `1` when the command was not found in `PATH`, which resulted in spurious advice under these conditions:

https://github.com/arduino/arduino-lint/runs/4577911186?check_suite_focus=true#step:3:11

```
An existing arduino-lint was found at . Please prepend "/home/runner/work/arduino-lint/arduino-lint/bin" to your $PATH or remove the existing one.
```

It seems safest to fix this by inverting the logic so that the advice about an existing installation in `PATH` is only
printed when one was found.

---

Attains sync with upstream "template" script: https://github.com/arduino/tooling-project-assets/pull/189

Checks for proper behavior of this aspect have been added for the parent: https://github.com/arduino/tooling-project-assets/actions/runs/1601562939

---

Originally reported at https://forum.arduino.cc/t/failing-to-instlal-arduino-cli-on-raspberry/936871