### PR TITLE
Avoid unnecessary `go list` command execution when running tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,17 +10,14 @@ vars:
   DIST_DIR: "dist"
   # Path of the project's primary Go module:
   DEFAULT_GO_MODULE_PATH: ./
-  DEFAULT_GO_PACKAGES:
-    sh: |
-      echo $( \
-        cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} \
-        && \
-        go list ./... | \
-          grep --invert-match 'github.com/arduino/arduino-lint/internal/rule/schema/schemadata' | \
-            tr '\n' ' ' \
-        || \
-        echo '"ERROR: Unable to discover Go packages"' \
-      )
+  DEFAULT_GO_PACKAGES: |
+    $( \
+      go list ./... | \
+        grep --invert-match 'github.com/arduino/arduino-lint/internal/rule/schema/schemadata' | \
+          tr '\n' ' ' \
+      || \
+      echo '"ERROR: Unable to discover Go packages"' \
+    )
   # build vars
   COMMIT:
     sh: echo "$(git log --no-show-signature -n 1 --format=%h)"


### PR DESCRIPTION
## Introduction

Go commands used during the development of this project may take a list of packages as argument. Generally, we will want to run the command on most of the packages of the targeted module, excluding selected packages which are not of interest (e.g., [the automatically generated `github.com/arduino/arduino-lint/internal/rule/schema/schemadata` package](https://github.com/arduino/arduino-lint/tree/4f0fa8b6a3a70d1f293fef732d54ff65e638ec23/internal/rule/schema/schemadata)).

The list of packages is generated using the `go list` command.

## Problem

Previously, the list was defined via [a "dynamic" taskfile variable](https://taskfile.dev/#/usage?id=dynamic-variables). The benefit to that approach was that the `go list` command ran only once per execution of [`task`](https://taskfile.dev/#/). However, there were some serious disadvantages:

### The module path could not be adjusted on the fly

The list would always be for the module path set at the time the `task` command ran (either by [setting the `GO_MODULE_PATH` environment variable in advance](https://github.com/arduino/arduino-lint/blob/4f0fa8b6a3a70d1f293fef732d54ff65e638ec23/.github/workflows/check-go-task.yml#L84), or by [the default of the repo root](https://github.com/arduino/arduino-lint/blob/4f0fa8b6a3a70d1f293fef732d54ff65e638ec23/Taskfile.yml#L12)). This meant it was not possible to call the Go tasks multiple times from an "umbrella" task to cover the multiple modules in the repository ([example](https://github.com/arduino/arduino-lint/blob/4f0fa8b6a3a70d1f293fef732d54ff65e638ec23/Taskfile.yml#L69-L75)).

### The `go list` command ran on all `task` executions

Many of the tasks don't have any need for the information generated by this command, meaning this was inefficient.

More significantly, this command can have a side effect of changing the dependency metadata a la `go mod tidy`.

Since [the CI ensures the project is always in a tidy state](https://github.com/arduino/arduino-lint/blob/4f0fa8b6a3a70d1f293fef732d54ff65e638ec23/.github/workflows/check-go-task.yml#L201), you would not expect this to cause an inappropriate diff. However, `go mod tidy` can have a different result depending on which version of Go is in use.

Although we always use the same version of Go for development and for the runs of the Go-related CI workflows, that is not done for the non Go-related workflows. This meant that the `go list` command ran with whatever Go version happened to be pre-installed in the GitHub Actions runner (currently 1.15.15), resulting in an unexpected diff. Since some of those workflows use `git diff` to detect problems, this would cause spurious workflow failures. For example:

https://github.com/arduino/arduino-lint/runs/5561403607?check_suite_focus=true#step:5:35

## Solution

The solution is to change this taskfile variable so that it is not "dynamic".

With this new approach, the variable is only a string, which is interpreted by the shell at the time of the task is ran.

Although this does mean that the `go list` command runs each time the variable occurs in the task being ran, in practice that does not usually result in inefficiency since most often the variable only occurs once in the task run via a `task` execution, and when it does occur multiple times it is in order to run the task for each module, in which case the `go list` command needs to run again anyway.