### PR TITLE
Configure "Check Go Dependencies" workflow to avoid failure of licensed installation

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -69,6 +69,12 @@ jobs:
         with:
           submodules: recursive
 
+      # This is required to allow jonabc/setup-licensed to install licensed via Ruby gem.
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Install latest version
+
       - name: Install licensed
         uses: jonabc/setup-licensed@v1
         with:
@@ -118,6 +124,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      # This is required to allow jonabc/setup-licensed to install licensed via Ruby gem.
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Install latest version
 
       - name: Install licensed
         uses: jonabc/setup-licensed@v1


### PR DESCRIPTION
The [**licensed**](https://github.com/github/licensed) tool is used to check for the project's compatibility with the licensing of its dependencies.

This tool is installed by the "Check Go Dependencies" GitHub Actions [workflow]([GitHub Actions workflow](https://docs.github.com/actions/using-workflows/about-workflows)) using [the `jonabc/setup-licensed` GitHub Actions action](https://github.com/jonabc/setup-licensed). This action attempts the installation according to the following procedure:

1. Install [the Ruby gem](https://rubygems.org/gems/licensed).
1. If gem installation fails, install the [release](https://github.com/github/licensed/releases/latest) asset from the `github/licensed` repo.

Spurious failures of the "Check Go Dependencies" workflow runs are occurring due to hitting [the rate limit](https://docs.github.com/rest/overview/resources-in-the-rest-api?#rate-limiting) during the attempt to install the release asset [via the GitHub API](https://docs.github.com/rest/releases/assets) in step (2).

The error message shown in the workflow run logs when this failure occurs:

https://github.com/arduino/arduino-lint/actions/runs/3747502835/jobs/6363797635#step:3:23

```text
Error: API rate limit exceeded for 104.45.203.178. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

suggests the rate limiting could be avoided by providing [an authentication token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) for the GitHub API request. However, [the workflow already does this](https://github.com/arduino/arduino-lint/blob/9269407d6ad3bfb9227250aa3ecc9593aca0fa68/.github/workflows/check-go-dependencies-task.yml#L75), and that token is used by the action, but [intentionally not](https://github.com/jonabc/setup-licensed/commit/0d9ebe79ce9ad895c06e2e79e91ba20033d10044) for this specific API request.

The problem would be avoided entirely if the gem installation at step (1) was successful. It was failing with the following error shown in the workflow run logs:

https://github.com/arduino/arduino-lint/actions/runs/3747502835/jobs/6363797635#step:3:13

```text
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /var/lib/gems/3.0.0 directory.
gem installation was not successful
```

As explained at https://github.com/jonabc/setup-licensed/issues/60#issuecomment-1007656099, this failure can be avoided by setting up an accessible installation of Ruby in the runner machine, which is accomplished using [the `ruby/setup-ruby` action](https://github.com/ruby/setup-ruby) in a step preceding the `jonabc/setup-licensed` steps in the workflow.