### PR TITLE
[AE-26] Increase Library name length from 16 to 32

### DIFF
--- a/etc/schemas/arduino-library-properties-definitions-schema.json
+++ b/etc/schemas/arduino-library-properties-definitions-schema.json
@@ -91,7 +91,7 @@
                 "$ref": "#/definitions/propertiesObjects/name/specification/object"
               },
               {
-                "maxLength": 64
+                "maxLength": 32
               },
               {
                 "$ref": "#/definitions/propertiesObjects/name/strict/definitions/patternObjects/notContainsSpaces"

--- a/etc/schemas/arduino-library-properties-definitions-schema.json
+++ b/etc/schemas/arduino-library-properties-definitions-schema.json
@@ -91,7 +91,7 @@
                 "$ref": "#/definitions/propertiesObjects/name/specification/object"
               },
               {
-                "maxLength": 16
+                "maxLength": 64
               },
               {
                 "$ref": "#/definitions/propertiesObjects/name/strict/definitions/patternObjects/notContainsSpaces"

--- a/internal/rule/ruleconfiguration/ruleconfiguration.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration.go
@@ -424,7 +424,7 @@ var configurations = []Type{
 		ID:               "LP010",
 		Brief:            "name > recommended length",
 		Description:      "The `name` field in the library's `library.properties` metadata file is longer than the recommended length. As the unique identifier for the library, the name will be typed by the users of command line tools (e.g., `arduino-cli lib install Servo`). For this reason, it is best practices to avoid unnecessary name length.",
-		MessageTemplate:  "library.properties name value {{.}} is longer than the recommended length of 64 characters.",
+		MessageTemplate:  "library.properties name value {{.}} is longer than the recommended length of 32 characters.",
 		Reference:        "https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format",
 		DisableModes:     nil,
 		EnableModes:      []rulemode.Type{rulemode.Default},

--- a/internal/rule/ruleconfiguration/ruleconfiguration.go
+++ b/internal/rule/ruleconfiguration/ruleconfiguration.go
@@ -424,7 +424,7 @@ var configurations = []Type{
 		ID:               "LP010",
 		Brief:            "name > recommended length",
 		Description:      "The `name` field in the library's `library.properties` metadata file is longer than the recommended length. As the unique identifier for the library, the name will be typed by the users of command line tools (e.g., `arduino-cli lib install Servo`). For this reason, it is best practices to avoid unnecessary name length.",
-		MessageTemplate:  "library.properties name value {{.}} is longer than the recommended length of 16 characters.",
+		MessageTemplate:  "library.properties name value {{.}} is longer than the recommended length of 64 characters.",
 		Reference:        "https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format",
 		DisableModes:     nil,
 		EnableModes:      []rulemode.Type{rulemode.Default},

--- a/internal/rule/rulefunction/library_test.go
+++ b/internal/rule/rulefunction/library_test.go
@@ -297,7 +297,7 @@ func TestLibraryPropertiesNameFieldGTRecommendedLength(t *testing.T) {
 	testTables := []libraryRuleFunctionTestTable{
 		{"Invalid", "InvalidLibraryProperties", ruleresult.NotRun, ""},
 		{"Legacy", "Legacy", ruleresult.NotRun, ""},
-		{"Name field longer than recommended", "NameGTRecommendedLength", ruleresult.Fail, ""},
+		{"Name field longer than recommended", "NameIsBiggerThanRecommendedLength", ruleresult.Fail, ""},
 		{"Valid", "Recursive", ruleresult.Pass, ""},
 	}
 

--- a/internal/rule/rulefunction/testdata/libraries/NameIsBiggerThanRecommendedLength/library.properties
+++ b/internal/rule/rulefunction/testdata/libraries/NameIsBiggerThanRecommendedLength/library.properties
@@ -1,4 +1,4 @@
-name=NameGTRecommendedLength
+name=NameIsBiggerThanRecommendedLength
 version=1.0.0
 author=Cristian Maglie <c.maglie@example.com>, Pippo Pluto <pippo@example.com>
 maintainer=Cristian Maglie <c.maglie@example.com>

--- a/internal/rule/schema/schemadata/bindata.go
+++ b/internal/rule/schema/schemadata/bindata.go
@@ -1509,7 +1509,7 @@ var _arduinoLibraryPropertiesDefinitionsSchemaJson = []byte(`{
                 "$ref": "#/definitions/propertiesObjects/name/specification/object"
               },
               {
-                "maxLength": 16
+                "maxLength": 32
               },
               {
                 "$ref": "#/definitions/propertiesObjects/name/strict/definitions/patternObjects/notContainsSpaces"


### PR DESCRIPTION
As reported in https://github.com/arduino/arduino-lint/issues/508 , the current linter rules limit the max number of characters for a library name to 16. 

https://github.com/arduino/arduino-lint/blob/c2c82d654e1cf2888112cfc83e3417342b163227/etc/schemas/arduino-library-properties-definitions-schema.json#L94

https://github.com/arduino/arduino-lint/blob/c2c82d654e1cf2888112cfc83e3417342b163227/internal/rule/ruleconfiguration/ruleconfiguration.go#L427

As noted by @aentinger , since Arduino libraries start with `Arduino_`, this leaves only 8 characters to describe the library according to the linter rules. **This PR increases the maximum length of a library name to ~64~ 32 characters**. For official libraries with the leading `Arduino_`, this provides ~56~ 24 characters which should be sufficent to describe the library in a UX-friendly manner.