### PR TITLE
Use project Go version for generating website content

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,6 +1,10 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
 name: Check Markdown
 
+env:
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
+  GO_VERSION: "1.17"
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -55,6 +59,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -2,6 +2,8 @@
 name: Deploy Website
 
 env:
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
+  GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
@@ -53,6 +55,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
The project documentation is published on [a companion website](https://arduino.github.io/arduino-lint/dev/). A GitHub Actions workflow is used to automatically update the website whenever any relevant file is changed in the repository. This website includes content generated from the project's Go code.

Previously, the default version of Go from the GitHub Actions runner machine was used for generating the documentation content. A recent update of this default Go version from 1.17 to 1.20 (https://github.com/actions/runner-images/issues/7276) caused the generation process to fail:

- https://github.com/arduino/arduino-lint/actions/runs/4955302482/jobs/8864585754#step:6:9
- https://github.com/arduino/arduino-lint/actions/runs/4923773621/jobs/8795994762#step:4:87

```text
task: [go:rule-docs] ./ruledocsgen ../docs/rules
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xa29866]

goroutine 1 [running]:
debug/elf.(*Section).ReadAt(0xc0003a4000?, {0xc000376000?, 0x24?, 0x23?}, 0x23?)
	<autogenerated>:1 +0x26
archive/zip.readDirectoryEnd({0xe9d780, 0xc000328b80}, 0x210)
	/opt/hostedtoolcache/go/1.20.4/x64/src/archive/zip/reader.go:581 +0xf5
archive/zip.(*Reader).init(0xc00030bc70, {0xe9d780?, 0xc000328b80}, 0x210)
	/opt/hostedtoolcache/go/1.20.4/x64/src/archive/zip/reader.go:124 +0x5c
archive/zip.NewReader({0xe9d780, 0xc000328b80}, 0x210)
	/opt/hostedtoolcache/go/1.20.4/x64/src/archive/zip/reader.go:103 +0x5e
github.com/daaku/go%2ezipexe.zipExeReaderElf({0xea05a0?, 0xc000120840}, 0x1846986)
	/home/runner/go/pkg/mod/github.com/daaku/go.zipexe@v1.0.1/zipexe.go:128 +0x8b
github.com/daaku/go%2ezipexe.NewReader({0xea05a0, 0xc000120840}, 0x0?)
	/home/runner/go/pkg/mod/github.com/daaku/go.zipexe@v1.0.1/zipexe.go:48 +0x98
github.com/daaku/go%2ezipexe.OpenCloser({0xc0001543c0?, 0xc000147390?})
	/home/runner/go/pkg/mod/github.com/daaku/go.zipexe@v1.0.1/zipexe.go:30 +0x57
github.com/cmaglie/go%2erice.init.0()
	/home/runner/go/pkg/mod/github.com/cmaglie/go.rice@v1.0.3/appended.go:42 +0x65
```

This error, and the general fragility that comes from the lack of control over the Go version, is avoided by configuring the workflow to use the specific version of Go that is used for development and validation of the project.

---

Demonstration in my fork of a successful run of the updated "**Deploy Website**" workflow: 

https://github.com/per1234/arduino-lint/actions/runs/4955499040/jobs/8864951607#step:7:23

Demonstration run of the updated "**Check Markdown**" workflow:

https://github.com/arduino/arduino-lint/actions/runs/4955538345/jobs/8865023358?pr=542#step:5:238

This run still fails, but the cause of the failure is now legitimate (broken links) rather than a spurious failure caused by the generation process erroring.