### PR TITLE
Configure permissions of `GITHUB_TOKEN` in workflows

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -27,6 +27,7 @@ jobs:
       (github.event_name != 'pull_request' && github.repository == 'arduino/arduino-lint') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'arduino/arduino-lint')
     runs-on: ubuntu-latest
+    permissions: {}
     strategy:
       fail-fast: false
 

--- a/.github/workflows/check-code-generation-task.yml
+++ b/.github/workflows/check-code-generation-task.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.determination.outputs.result }}
+    permissions: {}
     steps:
       - name: Determine if the rest of the workflow should run
         id: determination
@@ -51,6 +52,7 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions: {}
 
     steps:
       - name: Checkout local repository

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set environment variables

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -37,6 +37,7 @@ on:
 jobs:
   run-determination:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       result: ${{ steps.determination.outputs.result }}
     steps:
@@ -62,6 +63,8 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -118,6 +121,8 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   run-determination:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       result: ${{ steps.determination.outputs.result }}
     steps:
@@ -54,6 +55,8 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -89,6 +92,8 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -127,6 +132,8 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -165,6 +172,8 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -203,6 +212,8 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -31,6 +31,8 @@ on:
 jobs:
   check-license:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -36,6 +36,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -55,6 +57,8 @@ jobs:
 
   links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -37,6 +37,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -201,6 +201,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -33,6 +33,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -60,6 +62,8 @@ jobs:
 
   formatting:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -27,6 +27,8 @@ jobs:
   lint:
     name: ${{ matrix.configuration.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       # See: https://github.com/koalaman/shellcheck/releases/latest
@@ -89,6 +91,8 @@ jobs:
 
   formatting:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Set environment variables
@@ -132,6 +136,8 @@ jobs:
 
   executable:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -32,6 +32,7 @@ on:
 jobs:
   publish-determination:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       result: ${{ steps.determination.outputs.result }}
     steps:
@@ -51,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-determination
     if: needs.publish-determination.outputs.result == 'true'
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   create-nightly-artifacts:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -65,6 +67,9 @@ jobs:
     outputs:
       checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
       checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
+
+    permissions:
+      contents: read
 
     env:
       GON_CONFIG_PATH: gon.config.hcl
@@ -166,6 +171,7 @@ jobs:
   publish-nightly:
     runs-on: ubuntu-latest
     needs: notarize-macos
+    permissions: {}
 
     steps:
       - name: Download artifact
@@ -194,6 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-nightly
     if: failure() # Run if publish-nightly or any of its job dependencies failed
+    permissions: {}
 
     steps:
       - name: Report failure

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.determination.outputs.result }}
+    permissions: {}
     steps:
       - name: Determine if the rest of the workflow should run
         id: determination
@@ -57,6 +58,7 @@ jobs:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       prefix: ${{ steps.calculation.outputs.prefix }}
     steps:
@@ -75,6 +77,8 @@ jobs:
     needs: package-name-prefix
     name: Build ${{ matrix.os.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -135,6 +139,8 @@ jobs:
       - build
       - package-name-prefix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Download build artifacts

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   create-release-artifacts:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -71,6 +73,8 @@ jobs:
     outputs:
       checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
       checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
+    permissions:
+      contents: read
 
     env:
       GON_CONFIG_PATH: gon.config.hcl
@@ -172,6 +176,8 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: notarize-macos
+    permissions:
+      contents: write
 
     steps:
       - name: Download artifact

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   spellcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -55,6 +57,7 @@ jobs:
   download:
     needs: check
     runs-on: ubuntu-latest
+    permissions: {}
 
     strategy:
       matrix:
@@ -82,6 +85,9 @@ jobs:
   sync:
     needs: download
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Set environment variables

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.determination.outputs.result }}
+    permissions: {}
     steps:
       - name: Determine if the rest of the workflow should run
         id: determination
@@ -60,6 +61,8 @@ jobs:
   test:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.determination.outputs.result }}
+    permissions: {}
     steps:
       - name: Determine if the rest of the workflow should run
         id: determination
@@ -57,6 +58,8 @@ jobs:
     name: test (${{ matrix.module.path }} - ${{ matrix.operating-system }})
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   default:
+    permissions: {}
     strategy:
       fail-fast: false
 
@@ -47,6 +48,7 @@ jobs:
           "${PWD}/bin/${{ env.TOOL_NAME }}" --version
 
   bindir:
+    permissions: {}
     strategy:
       fail-fast: false
 
@@ -80,6 +82,7 @@ jobs:
           "${{ env.BINDIR }}/${{ env.TOOL_NAME }}" --version
 
   version:
+    permissions: {}
     strategy:
       fail-fast: false
 
@@ -109,6 +112,7 @@ jobs:
           "${PWD}/bin/${{ env.TOOL_NAME }}" --version | grep --fixed-strings "${{ env.VERSION }}"
 
   nightly:
+    permissions: {}
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
[`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) is an access token that is automatically generated and made accessible for use in GitHub Actions workflow runs. The global default permissions of this token for workflow runs in a trusted context (i.e., not triggered by a `pull_request` event from a fork) are set in the GitHub [enterprise](https://docs.github.com/en/enterprise-cloud@latest/admin/policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#enforcing-a-policy-for-workflow-permissions-in-your-enterprise)/[organization](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization)/[repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)'s administrative settings, giving it either read-only or write permissions in all scopes.

In the case of a read-only default configuration, any workflow operations that require write permissions would fail with an error like:

> 403: Resource not accessible by integration

In the case of a write default configuration, workflows have unnecessary permissions, which violates the security [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).

For this reason, GitHub Actions now allows fine grained control at a per-workflow or per-workflow job scope of the permissions provided to the token. This is done using the `permissions` workflow key, which is used here to configure the workflows for only the permissions required by each individual job:

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

## Configuration Granularity

I chose to always configure permissions at the job level even though in some cases the same permissions configuration could be used for all jobs in a workflow. Even if functionally equivalent, I think it is semantically more appropriate to always set the permissions at the job scope since the intention is to make the most granular possible permissions configuration. Hopefully this approach will increase the likelihood that appropriate permissions configurations will be made in any additional jobs that are added to the workflows in the future.

## Security Implications

The [automatic permissions downgrade](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) from write to read for workflow runs in an untrusted context (e.g., triggered by a `pull_request` event from a fork) is unaffected by this change.

## API Request Implications

Even when all permissions are withheld (`permissions: {}`), the token still provides [the authenticated API request rate limiting allowance](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions) (authenticating API requests to avoid rate limiting is a one of the uses of the token in these workflows).

## Excess Permissions

Read permissions are required in [the `contents` scope](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview) in order to checkout private repositories. Even though those permissions are not required when the workflows are installed in this public repository, the templates are intended to be applicable in public and private repositories both and so a small excess in permissions was chosen in order to use the upstream templates unmodified.

## Testing

I did demonstration runs in my fork of the workflows that are not triggered by this PR:

- "**Deploy Website**": https://github.com/per1234/arduino-lint/actions/runs/5374421999/jobs/9749771455
- "**Release**": https://github.com/per1234/arduino-lint/actions/runs/5374551501
- "**Publish Nightly Build**": https://github.com/per1234/arduino-lint/actions/runs/5374585257

I already made the same configuration change to the "**Sync Labels**" workflow in the `arduino/ArduinoCore-renesas` repo (https://github.com/arduino/ArduinoCore-renesas/pull/4) so you can see the run of the updated workflow in that repo: 

https://github.com/arduino/ArduinoCore-renesas/actions/runs/5368699575

### Failure of "Check Markdown" workflow run

This is unrelated to the changes proposed here. The same failure is occurring even in the runs from the `main` branch:

https://github.com/arduino/arduino-lint/actions/workflows/check-markdown-task.yml?query=branch%3Amain