### PR TITLE
Fix example file causing panic

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -193,7 +193,7 @@ func findSubprojects(superproject Type, apexSuperprojectType projecttype.Type) [
 	var immediateSubprojects []Type
 	for _, subprojectsFolderName := range subprojectsFolderNames {
 		subprojectsPath := superproject.Path.Join(subprojectsFolderName)
-		if subprojectsPath.Exist() && subprojectsPath.IsDir() {
+		if subprojectsPath.IsDir() {
 			directoryListing, err := subprojectsPath.ReadDir()
 			if err != nil {
 				panic(err)

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -193,7 +193,7 @@ func findSubprojects(superproject Type, apexSuperprojectType projecttype.Type) [
 	var immediateSubprojects []Type
 	for _, subprojectsFolderName := range subprojectsFolderNames {
 		subprojectsPath := superproject.Path.Join(subprojectsFolderName)
-		if subprojectsPath.Exist() {
+		if subprojectsPath.Exist() && subprojectsPath.IsDir() {
 			directoryListing, err := subprojectsPath.ReadDir()
 			if err != nil {
 				panic(err)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -429,3 +429,19 @@ func TestFindProjects(t *testing.T) {
 		}
 	}
 }
+
+func TestExamplefile(t *testing.T) {
+	// Set up directory structure of test library.
+	libraryPath, err := paths.TempDir().MkTempDir("TestExampleFile")
+	defer libraryPath.RemoveAll() // Clean up after the test.
+	require.Nil(t, err)
+	err = libraryPath.Join("TestExample.h").WriteFile([]byte{})
+	require.Nil(t, err)
+	// Create an example file in the library folder. This should not cause a panic and should be ignored since it's not a folder containing the examples
+	err = libraryPath.Join("example").WriteFile([]byte{})
+	require.Nil(t, err)
+
+	configuration.Initialize(test.ConfigurationFlags(), []string{libraryPath.String()})
+
+	assert.NotPanics(t, func() { FindProjects() }, "Example file should not cause panic")
+}


### PR DESCRIPTION
Having an `example` file in the library was causing the tool to panic, because it was being treated like a directory, but without checking if it was actually one.
The `example` file is just ignored now.
Close #751
The bug was discovered in https://github.com/arduino/library-registry/pull/4836