### PR TITLE
Refactor variables in release workflows

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -92,6 +92,11 @@ jobs:
             package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -135,7 +140,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -164,11 +169,11 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"
+          chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
           # Use of an array here is required for globbing
           PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_nightly-*${{ matrix.build.package-suffix }})
           tar -czvf "$PACKAGE_FILENAME" \
-            -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/" "${{ env.PROJECT_NAME }}" \
+            -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
             -C ../../ LICENSE.txt
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -8,7 +8,7 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduino-lint/
-  ARTIFACT_NAME: dist
+  ARTIFACT_PREFIX: dist-
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
@@ -27,15 +27,24 @@ jobs:
     strategy:
       matrix:
         os:
-          - Windows_32bit
-          - Windows_64bit
-          - Linux_32bit
-          - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
-          - macOS_64bit
-          - macOS_ARM64
+          - task: Windows_32bit
+            artifact-suffix: Windows_32bit
+          - task: Windows_64bit
+            artifact-suffix: Windows_64bit
+          - task: Linux_32bit
+            artifact-suffix: Linux_32bit
+          - task: Linux_64bit
+            artifact-suffix: Linux_64bit
+          - task: Linux_ARMv6
+            artifact-suffix: Linux_ARMv6
+          - task: Linux_ARMv7
+            artifact-suffix: Linux_ARMv7
+          - task: Linux_ARM64
+            artifact-suffix: Linux_ARM64
+          - task: macOS_64bit
+            artifact-suffix: macOS_64bit
+          - task: macOS_ARM64
+            artifact-suffix: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -50,17 +59,17 @@ jobs:
       - name: Build
         env:
           NIGHTLY: true
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.os.task }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os }}
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.os.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:
-    name: Notarize ${{ matrix.artifact.name }}
+    name: Notarize ${{ matrix.build.folder-suffix }}
     runs-on: macos-latest
     needs: create-nightly-artifacts
 
@@ -76,11 +85,11 @@ jobs:
 
     strategy:
       matrix:
-        artifact:
-          - name: darwin_amd64
-            path: "macOS_64bit.tar.gz"
-          - name: darwin_arm64
-            path: "macOS_ARM64.tar.gz"
+        build:
+          - folder-suffix: darwin_amd64
+            package-suffix: "macOS_64bit.tar.gz"
+          - folder-suffix: darwin_arm64
+            package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
       - name: Checkout repository
@@ -89,7 +98,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
+          pattern: ${{ env.ARTIFACT_PREFIX }}*
           merge-multiple: true
           path: ${{ env.DIST_DIR }}
 
@@ -126,7 +135,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -155,11 +164,11 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
+          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"
           # Use of an array here is required for globbing
-          PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_nightly-*${{ matrix.artifact.path }})
+          PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_nightly-*${{ matrix.build.package-suffix }})
           tar -czvf "$PACKAGE_FILENAME" \
-            -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
+            -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/" "${{ env.PROJECT_NAME }}" \
             -C ../../ LICENSE.txt
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
@@ -167,7 +176,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}-notarized-${{ matrix.artifact.name }}
+          name: ${{ env.ARTIFACT_PREFIX }}notarized-${{ matrix.build.folder-suffix }}
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   publish-nightly:
@@ -179,7 +188,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
+          pattern: ${{ env.ARTIFACT_PREFIX }}*
           merge-multiple: true
           path: ${{ env.DIST_DIR }}
 

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -75,7 +75,7 @@ jobs:
 
   build:
     needs: package-name-prefix
-    name: Build ${{ matrix.os.name }}
+    name: Build ${{ matrix.os.artifact-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,31 +85,31 @@ jobs:
         os:
           - task: Windows_32bit
             path: "*Windows_32bit.zip"
-            name: Windows_X86-32
+            artifact-name: Windows_X86-32
           - task: Windows_64bit
             path: "*Windows_64bit.zip"
-            name: Windows_X86-64
+            artifact-name: Windows_X86-64
           - task: Linux_32bit
             path: "*Linux_32bit.tar.gz"
-            name: Linux_X86-32
+            artifact-name: Linux_X86-32
           - task: Linux_64bit
             path: "*Linux_64bit.tar.gz"
-            name: Linux_X86-64
+            artifact-name: Linux_X86-64
           - task: Linux_ARMv6
             path: "*Linux_ARMv6.tar.gz"
-            name: Linux_ARMv6
+            artifact-name: Linux_ARMv6
           - task: Linux_ARMv7
             path: "*Linux_ARMv7.tar.gz"
-            name: Linux_ARMv7
+            artifact-name: Linux_ARMv7
           - task: Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
-            name: Linux_ARM64
+            artifact-name: Linux_ARM64
           - task: macOS_64bit
             path: "*macOS_64bit.tar.gz"
-            name: macOS_64
+            artifact-name: macOS_64
           - task: macOS_ARM64
             path: "*macOS_ARM64.tar.gz"
-            name: macOS_ARM64
+            artifact-name: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -132,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
-          name: ${{ matrix.os.name }}
+          name: ${{ matrix.os.artifact-name }}
 
   checksums:
     needs:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -97,6 +97,11 @@ jobs:
             package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -140,7 +145,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -169,11 +174,11 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"
+          chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
           tar -czvf "$PACKAGE_FILENAME" \
-          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/" "${{ env.PROJECT_NAME }}" \
+          -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -8,7 +8,7 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduino-lint/
-  ARTIFACT_NAME: dist
+  ARTIFACT_PREFIX: dist-
 
 on:
   push:
@@ -24,15 +24,24 @@ jobs:
     strategy:
       matrix:
         os:
-          - Windows_32bit
-          - Windows_64bit
-          - Linux_32bit
-          - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
-          - macOS_64bit
-          - macOS_ARM64
+          - task: Windows_32bit
+            artifact-suffix: Windows_32bit
+          - task: Windows_64bit
+            artifact-suffix: Windows_64bit
+          - task: Linux_32bit
+            artifact-suffix: Linux_32bit
+          - task: Linux_64bit
+            artifact-suffix: Linux_64bit
+          - task: Linux_ARMv6
+            artifact-suffix: Linux_ARMv6
+          - task: Linux_ARMv7
+            artifact-suffix: Linux_ARMv7
+          - task: Linux_ARM64
+            artifact-suffix: Linux_ARM64
+          - task: macOS_64bit
+            artifact-suffix: macOS_64bit
+          - task: macOS_ARM64
+            artifact-suffix: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -42,7 +51,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.os == 'Windows_32bit'
+        if: matrix.os.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -57,17 +66,17 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.os.task }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os }}
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.os.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:
-    name: Notarize ${{ matrix.artifact.name }}
+    name: Notarize ${{ matrix.build.folder-suffix }}
     runs-on: macos-latest
     needs: create-release-artifacts
     outputs:
@@ -81,11 +90,11 @@ jobs:
 
     strategy:
       matrix:
-        artifact:
-          - name: darwin_amd64
-            path: "macOS_64bit.tar.gz"
-          - name: darwin_arm64
-            path: "macOS_ARM64.tar.gz"
+        build:
+          - folder-suffix: darwin_amd64
+            package-suffix: "macOS_64bit.tar.gz"
+          - folder-suffix: darwin_arm64
+            package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
       - name: Checkout repository
@@ -94,7 +103,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
+          pattern: ${{ env.ARTIFACT_PREFIX }}*
           merge-multiple: true
           path: ${{ env.DIST_DIR }}
 
@@ -131,7 +140,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -160,11 +169,11 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
+          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.artifact.path }}"
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
           tar -czvf "$PACKAGE_FILENAME" \
-          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
+          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
@@ -172,7 +181,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}-notarized-${{ matrix.artifact.name }}
+          name: ${{ env.ARTIFACT_PREFIX }}notarized-${{ matrix.build.folder-suffix }}
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-release:
@@ -185,7 +194,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
+          pattern: ${{ env.ARTIFACT_PREFIX }}*
           merge-multiple: true
           path: ${{ env.DIST_DIR }}
 

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -101,6 +101,8 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -175,12 +177,9 @@ jobs:
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
-          TAG="${GITHUB_REF/refs\/tags\//}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
-          tar -czvf "$PACKAGE_FILENAME" \
+          tar -czvf "${{ env.PACKAGE_FILENAME }}" \
           -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
-          echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
GitHub Actions workflows are used to automatically generate beta tester and production builds of the project.

A separate build is generated for each of the target host types. This is done using a job matrix, which creates a parallel run of the workflow job for each target. The matrix defines variables that provide the data that is specific to each job.

The variable names used previously did not clearly communicate their nature:

- The variable for the task name was named "os"
- The variables for the build filename components used the term "artifact", which is ambiguous in this context where the term is otherwise used to refer to the completely unrelated workflow artifacts

These variable names made it very difficult for anyone not intimately familiar with the workings of the workflow to understand its code.