### PR TITLE
Add schedule triggers to workflows whenever possible

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -22,6 +22,9 @@ on:
       - "**/go.mod"
       - "**/go.sum"
       - "**.go"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 7 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -26,6 +26,9 @@ on:
       - "[lL][iI][cC][eE][nN][cCsS][eE]*"
       - "[oO][fF][lL]*"
       - "[pP][aA][tT][eE][nN][tT][sS]*"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 6 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -32,6 +32,9 @@ on:
       - "docsgen/**"
       - "ruledocsgen/**"
       - "**.go"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 5 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -196,6 +196,9 @@ on:
       - "**.rviz"
       - "**.sublime-syntax"
       - "**.syntax"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 4 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -28,6 +28,9 @@ on:
       - "Taskfile.ya?ml"
       - "**/tox.ini"
       - "**.py"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -30,6 +30,9 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - "tests/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 10 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -26,6 +26,9 @@ on:
       - "Taskfile.ya?ml"
       - "**.go"
       - "**/testdata/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 11 * * WED"
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
This repository contains several GitHub Actions workflows to facilitate the development and maintenance.

The workflows are typically configured to run whenever any relevant file in the repository is changed. However, the results of the workflow run are also dependent on the external environment it runs in, which include:

- The software running on the GitHub hosted GitHub Actions runner machines
- The GitHub Actions actions used by the workflow
- The dependencies that are installed by the workflow directly or via the GitHub Actions actions it uses

The workflows often do not fully pin to a specific version of given external tool. This was done in the interest on reducing the maintenance burden of keeping the systems up to date. However, it also means that a new release can cause the workflow runs to start failing (which might happen through an enhancement to that resource resolving a false negative, or a defect causing a false negative).

When the repository file path trigger is used by itself, this sort of external breakage is only revealed when an unrelated change triggers the workflow. That can be distracting even to a dedicated member of the project development team, as well as confusing and discouraging to any contributor.

This type of change can be caught by adding a `schedule` event trigger that causes the workflow to run periodically in addition to the other on-demand triggers. This allows the problem to be identified and resolved at the maintainer's convenience, separate from the unrelated development work.