### PR TITLE
Add support to "Check License" for checking license files in multiple paths

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,11 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
 name: Check License
 
-env:
-  EXPECTED_LICENSE_FILENAME: LICENSE.txt
-  # SPDX identifier: https://spdx.org/licenses/
-  EXPECTED_LICENSE_TYPE: GPL-3.0
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -58,11 +53,22 @@ jobs:
           echo "result=$RESULT" >> $GITHUB_OUTPUT
 
   check-license:
+    name: ${{ matrix.check-license.path }}
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        check-license:
+          - path: ./
+            expected-filename: LICENSE.txt
+            # SPDX identifier: https://spdx.org/licenses/
+            expected-type: GPL-3.0
 
     steps:
       - name: Checkout repository
@@ -76,23 +82,27 @@ jobs:
       - name: Install licensee
         run: gem install licensee
 
-      - name: Check license file
+      - name: Check license file for ${{ matrix.check-license.path }}
         run: |
           EXIT_STATUS=0
+
+          # Go into folder path
+          cd ./${{ matrix.check-license.path }}
+
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
-          if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+          if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.expected-filename }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.expected-filename }}"
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
-          if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${EXPECTED_LICENSE_TYPE}\""
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.expected-type }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.expected-type }}\""
             EXIT_STATUS=1
           fi
 


### PR DESCRIPTION
In cases where a project contains distinct components in subfolders, multiple license files might be present.

Previously the "Check License" workflow only supported checking the license file in the root of the repository. Support for validating an arbitrary number of license files with arbitrary locations, types, and filenames is added. A job matrix is used to provide this support in a manner that makes application-specific configuration of the workflow easy and without code duplication.