### PR TITLE
Add support to "Test Go" workflow for alternative Codecov configuration paths

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -11,7 +11,9 @@ on:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "codecov.ya?ml"
+      - ".github/.?codecov.ya?ml"
+      - "dev/.?codecov.ya?ml"
+      - ".?codecov.ya?ml"
       - "**/go.mod"
       - "**/go.sum"
       - "Taskfile.ya?ml"
@@ -20,7 +22,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "codecov.ya?ml"
+      - ".github/.?codecov.ya?ml"
+      - "dev/.?codecov.ya?ml"
+      - ".?codecov.ya?ml"
       - "**/go.mod"
       - "**/go.sum"
       - "Taskfile.ya?ml"


### PR DESCRIPTION
For the sake of efficiency, the "Test Go" GitHub Actions workflow is [configured](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) to run only when relevant files are modified. Since the workflow uploads code coverage data to [Codecov](https://about.codecov.io/), the Codecov configuration file is one of these files.

The standard filename for the Codecov configuration file is `codecov.yml`, and the workflow's path filter was configured for that filename. It turns out an alternative filename is also recognized: `.codecov.yml`. Two subfolders are also supported in addition to the root of the repository as locations for the configuration file.

https://docs.codecov.com/docs/codecov-yaml#can-i-name-the-file-codecovyml

The workflow's paths filter was not configured for the alternative filename and locations, meaning the workflow would not be triggered on change to the Codecov configuration in projects that use the alternative configuration file name or locations.

The workflow's paths filter is hereby configured to recognize changes to any valid Codecov configuration file.