### PR TITLE
Expand ignored path configurations

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ot,porperties,propert
-skip = ./.git,./.licenses,**/go.mod,**/go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./arduino-lint,./arduino-lint.exe,./internal/rule/rulefunction/testdata/libraries/MisspelledSentenceParagraphValue/library.properties,./site
+skip = ./.git,./.licenses,**/go.mod,**/go.sum,__pycache__,./package-lock.json,./poetry.lock,./yarn.lock,./arduino-lint,./arduino-lint.exe,./internal/rule/rulefunction/testdata/libraries/MisspelledSentenceParagraphValue/library.properties,./site
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.ecrc
+++ b/.ecrc
@@ -1,5 +1,7 @@
 {
   "Exclude": [
+    "^\\.git[/\\\\]",
+    "__pycache__[/\\\\]",
     "^LICENSE\\.txt$",
     "^poetry\\.lock$",
     "^\\.licenses/",

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown/.markdownlintignore
+.licenses/
+__pycache__/

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@
 
 # Generated files
 /.licenses/
+__pycache__/
 
 # Test files
 /internal/rule/schema/testdata/input/invalid-schema.json


### PR DESCRIPTION
In order to avoid spurious results and to improve efficiency, automatically generated or externally maintained files should be excluded from automated processes. The coverage of ignore configurations is hereby expanded to cover more paths containing such files.