### PR TITLE
Don't run "Publish Tester Build" workflow on tag push

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -40,10 +40,12 @@ jobs:
         id: determination
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          TAG_REGEX="refs/tags/.*"
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[
-            "${{ github.event_name }}" != "create" ||
-            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+            ("${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX) &&
+            ! "${{ github.ref }}" =~ $TAG_REGEX
           ]]; then
             # Run the other jobs.
             RESULT="true"


### PR DESCRIPTION
The "Publish Tester Build" workflow is triggered by the [`push` event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#push). This event occurs on tag pushes in addition to commit pushes.

On a tag push, there is an ambiguity in how the build should be identified, since the revision has two Git refs:

- The commit hash
- The tag name

The build system intentionally uses the tag name ref to name the build archives, but the workflow's checksum file generation code expects the files to be named using the commit hash ref. This resulted in a spurious failure of the "Create checksum file" step of the `checksums` job with an error of the form:

```
sha256sum: 'arduino-lint_test-052e9032aa396ac0a4c356eaf7c8dc5ca3f4ad4b-git-snapshot*': No such file or directory
Error: Process completed with exit code 1.
```

The ref selection behavior of the checksum generation code could be corrected. However, there is no point in generating a tester build on tag push, since a tester build will have already been generated for that revision previously via the commit push, and any necessary validation already performed prior to the tag push. The "Release" workflow is triggered by the tag push so builds are produced for that revision regardless. For this reason, the correct resolution for this bus is to prevent the production of a tester build when the workflow is triggered by the tag push.

To fix this issue, the `run-determination` job is configured to check for the presence of a tag by comparing `github.ref` against a regular expression (defined via the `TAG_REGEX` shell environment variable). If there is a match, the other jobs are skipped, preventing the workflow from failing at later stages.