### PR TITLE
Add Windows path support to editorconfig-checker exclude regex

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -4,7 +4,7 @@
     "__pycache__[/\\\\]",
     "^LICENSE\\.txt$",
     "^poetry\\.lock$",
-    "^\\.licenses/",
+    "^\\.licenses[/\\\\]",
     "^internal/rule/schema/schemadata/bindata.go$",
     "^internal/rule/schema/testdata/bindata.go$"
   ]


### PR DESCRIPTION
The `Exclude` key of the `.ecrc` configuration file specifies regular expressions of paths that should be ignored by the editorconfig-checker tool. Previously, the regular expression only accommodated the POSIX-compliant path separator, meaning the path was not excluded as intended when used on a Windows system (even when ran from a Bash shell).