### PR TITLE
Add support for non-bundled X.509 certificates to "Check Certificates" workflow

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -76,6 +76,7 @@ jobs:
           - identifier: macOS signing certificate # Text used to identify certificate in notifications.
             certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
             password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
+            type: pkcs12
 
     steps:
       - name: Set certificate path environment variable
@@ -94,7 +95,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets[matrix.certificate.password-secret] }}
         run: |
           (
-            openssl pkcs12 \
+            openssl ${{ matrix.certificate.type }} \
               -in "${{ env.CERTIFICATE_PATH }}" \
               -legacy \
               -noout \
@@ -121,26 +122,43 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets[matrix.certificate.password-secret] }}
         id: get-days-before-expiration
         run: |
-          EXPIRATION_DATE="$(
-            (
-              openssl pkcs12 \
-                -in "${{ env.CERTIFICATE_PATH }}" \
-                -clcerts \
-                -legacy \
-                -nodes \
-                -passin env:CERTIFICATE_PASSWORD
-            ) | (
-              openssl x509 \
-                -noout \
-                -enddate
-            ) | (
-              grep \
-                --max-count=1 \
-                --only-matching \
-                --perl-regexp \
-                'notAfter=(\K.*)'
-            )
-          )"
+          if [[ ${{ matrix.certificate.type }} == "pkcs12" ]]; then
+            EXPIRATION_DATE="$(
+                (
+                openssl pkcs12 \
+                    -in ${{ env.CERTIFICATE_PATH }} \
+                    -clcerts \
+                    -legacy \
+                    -nodes \
+                    -passin env:CERTIFICATE_PASSWORD
+                ) | (
+                openssl x509 \
+                    -noout \
+                    -enddate
+                ) | (
+                grep \
+                    --max-count=1 \
+                    --only-matching \
+                    --perl-regexp \
+                    'notAfter=(\K.*)'
+                )
+            )"
+          elif [[ ${{ matrix.certificate.type }} == "x509" ]]; then
+            EXPIRATION_DATE="$(
+                (
+                openssl x509 \
+                    -in ${{ env.CERTIFICATE_PATH }} \
+                    -noout \
+                    -enddate
+                ) | (
+                grep \
+                    --max-count=1 \
+                    --only-matching \
+                    --perl-regexp \
+                    'notAfter=(\K.*)'
+                )
+            )"
+          fi
 
           DAYS_BEFORE_EXPIRATION="$((($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24))"
 


### PR DESCRIPTION
The digital certificates used for code signing are often stored in an archive file of the [PKCS #12](https://en.wikipedia.org/wiki/PKCS_12) format, which allows multiple objects to be bundled in a single file.

However, it also might occur that a single certificate is stored in [X.509](https://en.wikipedia.org/wiki/X.509) format.

Previously, the "Check Certificates" workflow only supported certificates in a PKCS #12 archive. Support is hereby added to the workflow for validation of X.509 certificates in addition to PKCS #12.