### PR TITLE
Use npm to manage Prettier tool dependency

### DIFF
--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -1,6 +1,10 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
 name: Check Prettier Formatting
 
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 20.x
+
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -237,6 +241,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -200,6 +200,8 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
   general:format-prettier:
     desc: Format all supported files with Prettier
+    deps:
+      - task: npm:install-deps
     cmds:
       - npx prettier --write .
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "devDependencies": {
         "markdown-link-check": "3.11.2",
-        "markdownlint-cli": "0.37.0"
+        "markdownlint-cli": "0.37.0",
+        "prettier": "3.3.3"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1156,6 +1157,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/progress": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "devDependencies": {
     "markdown-link-check": "3.11.2",
-    "markdownlint-cli": "0.37.0"
+    "markdownlint-cli": "0.37.0",
+    "prettier": "3.3.3"
   },
   "type": "module"
 }


### PR DESCRIPTION
The project uses the Prettier tool to format various file types. Previously, the version of the tool used was not controlled. This was problematic because:

- A different version of the tool may be used on the contributor's machine than on the CI runner, resulting in confusing failures.
- The project is immediately subject to disruption or breakage resulting from a release of the tool.

The new approach is to specify the version of the tools via the standard npm metadata files (package.json + package-lock.json), providing the following benefits:

- Enables automated updates via Dependabot PRs
- Enables automated vulnerability alerts