### PR TITLE
Configure Dependabot to check for outdated npm package dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,16 @@ updates:
     labels:
       - "topic: infrastructure"
 
+  - package-ecosystem: npm
+    directory: /
+    assignees:
+      - per1234
+    open-pull-requests-limit: 100
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+
   - package-ecosystem: pip
     directory: /
     assignees:


### PR DESCRIPTION
Dependabot will periodically check all npm package dependencies of the project. If any are found to be outdated, it will submit a pull request to update them.