### PR TITLE
Use engines.node as source of version data for "actions/setup-node" action

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -4,8 +4,6 @@ name: Check Markdown
 env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
 
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
@@ -79,7 +77,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Initialize markdownlint-cli problem matcher
         uses: xt0rted/markdownlint-problem-matcher@v3
@@ -112,7 +110,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-npm-task.md
 name: Check npm
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -72,7 +68,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -105,7 +101,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
 name: Check Prettier Formatting
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -245,7 +241,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -84,6 +84,8 @@ If you want to run integration tests or work on documentation, you will also nee
 - A working [Python](https://www.python.org/downloads/) environment, version 3.9 or later.
 - [Poetry](https://python-poetry.org/docs/).
 - [**Node.js** / **npm**](https://nodejs.org/en/download/) - Node.js dependencies management tool.
+  - The **Node.js** version in use is defined in the `engines.node` field of
+    [`package.json`](https://github.com/arduino/arduino-lint/blob/main/package.json).
   - **ⓘ** [**nvm**](https://github.com/nvm-sh/nvm#installing-and-updating) is recommended if you want to manage multiple
     installations of **Node.js** on your system.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
         "markdown-link-check": "3.11.2",
         "markdownlint-cli": "0.37.0",
         "prettier": "3.3.3"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
     "markdownlint-cli": "0.37.0",
     "prettier": "3.3.3"
   },
+  "engines": {
+    "node": "20.x"
+  },
   "type": "module"
 }


### PR DESCRIPTION
The "actions/setup-node" GitHub Actions action is used to set up Node.js in the GitHub Actions runner machine.

The action supports obtaining the Node.js version to set up from the `engines.node` property of the package.json file.

This allows us to define the standardized version of Node.js for use by project contributors in a single place rather than having to maintain multiple instances of that data.