### PR TITLE
Configure npm to enforce standard project Node.js version

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - ".github/workflows/check-markdown-task.ya?ml"
       - ".markdown-link-check.json"
+      - "**/.npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"
@@ -24,6 +25,7 @@ on:
     paths:
       - ".github/workflows/check-markdown-task.ya?ml"
       - ".markdown-link-check.json"
+      - "**/.npmrc"
       - "package.json"
       - "package-lock.json"
       - "Taskfile.ya?ml"

--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -13,8 +13,11 @@ on:
   push:
     paths:
       - ".github/workflows/check-mkdocs-task.ya?ml"
+      - "**/.npmrc"
       - "Taskfile.ya?ml"
       - "mkdocs.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "poetry.lock"
       - "pyproject.toml"
       - "docs/**"
@@ -24,8 +27,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/check-mkdocs-task.ya?ml"
+      - "**/.npmrc"
       - "Taskfile.ya?ml"
       - "mkdocs.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "poetry.lock"
       - "pyproject.toml"
       - "docs/**"
@@ -86,6 +92,11 @@ jobs:
 
       - name: Install Poetry
         run: pip install poetry
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -7,12 +7,14 @@ on:
   push:
     paths:
       - ".github/workflows/check-npm-task.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-npm-task.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
       - "Taskfile.ya?ml"
+      - "**/.npmrc"
       - "**/.prettierignore"
       - "**/.prettierrc*"
       # CSS
@@ -104,6 +105,7 @@ on:
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
       - "Taskfile.ya?ml"
+      - "**/.npmrc"
       - "**/.prettierignore"
       - "**/.prettierrc*"
       # CSS

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# See: https://docs.npmjs.com/cli/configuring-npm/npmrc
+
+engine-strict = true


### PR DESCRIPTION
This will produce an error if a contributor attempts to run an npm command in the project using an unsupported version
of Node.js.