### PR TITLE
Configure script path in shell-related task calls in umbrella tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -76,7 +76,11 @@ tasks:
       - task: markdown:check-links
       - task: python:lint
       - task: shell:check
+        vars:
+          SCRIPT_PATH: etc/install.sh
       - task: shell:check-mode
+        vars:
+          SCRIPT_PATH: etc/install.sh
       - task: website:check
 
   fix:
@@ -109,6 +113,8 @@ tasks:
       - task: markdown:fix
       - task: python:format
       - task: shell:format
+        vars:
+          SCRIPT_PATH: etc/install.sh
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
   ci:validate:


### PR DESCRIPTION
The tasks for facilitating development and validation of shell scripts were recently adjusted to target specific scripts (https://github.com/arduino/arduino-lint/pull/773). After that change, it is necessary to specify the path to the script in the task call.

For the convenience of the contributor, the taskfile contains some "umbrella" tasks that call all of the tasks of a given type. These call the shell-related tasks. Those calls were not updated at the time the shell tasks were changed to a targeted approach so previously they were not functional.