### PR TITLE
Add support for dependencies preparation to `general:cache-dep-licenses` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,6 +157,8 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
     desc: Cache dependency license metadata
+    deps:
+      - task: general:prepare-deps
     cmds:
       - |
         if ! which licensed &>/dev/null; then
@@ -214,6 +216,11 @@ tasks:
       - task: npm:install-deps
     cmds:
       - npx prettier --write .
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
+  general:prepare-deps:
+    desc: Prepare project dependencies for license check
+    # No preparation is needed for Go module-based projects.
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   go:build:


### PR DESCRIPTION
The `general:cache-dep-licenses` task is used to generate metadata about the licenses of the project's dependencies.

When using some dependency management systems, it is necessary to run an operation via the dependency management tool prior to generating the metadata. A task call was added to the `general:cache-dep-licenses` task in order to allow it to be used with such project types. It happens that such a preparatory operation is not necessary with the Go modules dependency management system used by this project, so the preparation task is left empty.