### PR TITLE
Convert absolute paths used in `ci:validate` task to Windows format

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,7 +123,7 @@ tasks:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
       WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow
       WORKFLOW_SCHEMA_PATH:
-        sh: mktemp -t workflow-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="workflow-schema-XXXXXXXXXX.json"
       WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
     deps:
       - task: npm:install-deps


### PR DESCRIPTION
The Task task runner tool uses an integrated Bash shell interpreter to allow the use of standard POSIX/Bash syntax and built-in utilities while providing cross-platform support for users who have made the poor choice of the non-standard Windows cmd or PowerShell shells.

While this is a nice feature of Task, distinguishing it from other alternatives, it is still often necessary to use non-built-in utilities. So use of a Bash shell is a requirement to run our tasks even the developers using Windows.

Although high quality Bash shells for Windows such as the Git Bash included as part of the Git for Windows installation generally provide a seamless experience, there is the occasional "gotcha".

Relative paths work the same for POSIX and Windows, but absolute POSIX format paths may not. These paths are handled as expected by Task's integrated shell interpreter and by Bash, but when these paths are used outside that context they may no longer be correct.

For example:

```
  foo:
    cmds:
      - mkdir "/tmp/posix-path-test-dir"
      - touch "/tmp/posix-path-test-dir/posix-path-test-file"
      - ls "/tmp/posix-path-test-dir"
      - cd "/tmp/posix-path-test-dir"
```

The first three commands work as expected, but the `cd` command fails:

```
$ task foo
task: [foo] mkdir "/tmp/posix-path-test-dir"
task: [foo] touch "/tmp/posix-path-test-dir/posix-path-test-file"
task: [foo] ls "/tmp/posix-path-test-dir"
posix-path-test-file
task: [foo] cd "/tmp/posix-path-test-dir"
task: Failed to run task "foo": exit status 1
```

The POSIX format `/tmp` is actually set to the system temporary directory:

```
$ cygpath -w "/tmp/posix-path-test-dir"
C:\Users\per\AppData\Local\Temp\posix-path-test-dir
```

But if treated as a Windows format path, this would be the `tmp` subfolder of the root of the current drive (e.g., `C:\tmp`). Even though the command was run from Git Bash, which provides a `cd` that handles this absolute path perfectly, when run from Task the Windows native `cd` is used instead.

This resulted in the `ci:validate` validation task, which downloads the JSON schema to the temporary folder, to fail when ran on Windows.

The solution is to convert the absolute paths to Windows format (which is handled fine by both the integrated, Bash, and external applications) when the task is ran on a Windows machine. The cygpath utility provides this capability:

```
$ task foo
task: [foo] mkdir "C:\Users\per\AppData\Local\Temp/posix-path-test-dir"
task: [foo] touch "C:\Users\per\AppData\Local\Temp/posix-path-test-dir/posix-path-test-file"
task: [foo] ls "C:\Users\per\AppData\Local\Temp/posix-path-test-dir"
posix-path-test-file
task: [foo] cd "C:\Users\per\AppData\Local\Temp/posix-path-test-dir"
```