### PR TITLE
Install standard version of Node.js in "Deploy Website" workflow

### DIFF
--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/deploy-cobra-mkdocs-versioned-poetry.ya?ml"
+      - "**/.npmrc"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
@@ -24,6 +25,8 @@ on:
       - "docsgen/**"
       - "ruledocsgen/**"
       - "mkdocs.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "poetry.lock"
       - "pyproject.toml"
   # Run on branch or tag creation (will be filtered by the publish-determination job).
@@ -79,6 +82,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2


### PR DESCRIPTION
The "Deploy Website" workflow invokes the following chain of tasks:

1. `docs:generate`
2. `general:format-prettier`

This makes the Prettier tool a dependency of the workflow, which in turn introduces a dependency on npm, and thus on Node.js.

Previously, the workflow didn't contain a step to run the "actions/setup-node" action, so it used whichever version of npm happened to be installed in the runner machine, which happens to be 18.x currently. Now that the use of the project's standard Node.js version 20.x is enforced, this caused the workflow runs to fail spuriously:

```
task: [npm:install-deps] npm install
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: undefined
npm error notsup Not compatible with your version of node/npm: undefined
npm error notsup Required: {"node":"20.x"}
npm error notsup Actual:   {"npm":"10.7.0","node":"v18.20.4"}

npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2024-10-16T07_28_37_785Z-debug-0.log
task: Failed to run task "docs:generate": exit status 1
```

The problem is solved by adding an "actions/setup-node" action step to the workflow to install the correct version of Node.js.