### PR TITLE
Use `pyproject.toml` as Python version source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# See: https://git-scm.com/docs/gitattributes
+
+# Disable Git converting line endings in files (i.e., core.autocrlf=true).
+* -text

--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -4,8 +4,6 @@ name: Check Website
 env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
-  PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
@@ -88,7 +86,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-python-task.md
 name: Check Python
 
-env:
-  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
-  PYTHON_VERSION: "3.9"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -73,7 +69,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry
@@ -104,7 +100,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -4,8 +4,6 @@ name: Deploy Website
 env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
-  PYTHON_VERSION: "3.9"
 
 on:
   push:
@@ -76,7 +74,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md
 name: Spell Check
 
-env:
-  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
-  PYTHON_VERSION: "3.9"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -55,7 +51,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -4,8 +4,6 @@ name: Test Integration
 env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
-  PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
@@ -88,7 +86,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Install Poetry
         run: pip install poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -1007,5 +1007,5 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "8ca37cdfb803b49f142e2cdb113a3670790b01225c7675ce32e4c4fbd1f4f6d0"
+python-versions = "~3.9"
+content-hash = "48ba2dd5d43822a3d627472ddc23455844a3218b5a74a9fdecaf7b99ac3a279d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "arduino-lint"
 authors = ["Arduino <info@arduino.cc>"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "~3.9"
 
 # Integration tests dependencies.
 invoke = "^2.2.0"


### PR DESCRIPTION
Python and Python-based tools are used in the development and maintenance of the project. A standardized version of Python is used for these operations.

Poetry is used for Python package dependencies management. Poetry installs dependencies into a virtual environment. For this reason, the Poetry configuration includes a Python version number, which must match the correct version of Python for the project. This configuration is stored in the [`pyproject.toml` file](https://python-poetry.org/docs/pyproject/).

Python is installed in the GitHub Actions runner environments using the **actions/setup-python** action, which also must be configured to install the correct version of Python. Previously the version number for use by the actions/setup-python action was defined in each workflow. This meant that we had multiple copies of the Python version information, all of which had to be kept in sync.

Fortunately, support for using `pyproject.toml` as the source of version information for the **actions/setup-python** action was recently added (https://github.com/actions/setup-python/commit/0d5da6a89a3aa5b4dbd48e38b0c9d678b0caa0e5). This means it is now possible for all components of the project infrastructure to get the Python version from a single source.