### PR TITLE
Use `go.mod` as source of Go version number for workflows

### DIFF
--- a/.github/workflows/check-code-generation-task.yml
+++ b/.github/workflows/check-code-generation-task.yml
@@ -1,9 +1,5 @@
 name: Check Code Generation
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 on:
   create:
   push:
@@ -61,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md
 name: Check Go Dependencies
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -87,7 +83,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -146,7 +142,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-task.md
 name: Check Go
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -77,7 +73,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -114,7 +110,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -154,7 +150,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -194,7 +190,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -234,7 +230,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
 name: Check Markdown
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -17,6 +13,8 @@ on:
       - "package-lock.json"
       - "Taskfile.ya?ml"
       - "**/.markdownlint*"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.mdx?"
       - "**.mkdn"
       - "**.mdown"
@@ -30,6 +28,8 @@ on:
       - "package-lock.json"
       - "Taskfile.ya?ml"
       - "**/.markdownlint*"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.mdx?"
       - "**.mkdn"
       - "**.mdown"
@@ -107,7 +107,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-mkdocs-task.md
 name: Check Website
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -12,6 +8,8 @@ on:
     paths:
       - ".github/workflows/check-mkdocs-task.ya?ml"
       - "**/.npmrc"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "mkdocs.ya?ml"
       - "package.json"
@@ -26,6 +24,8 @@ on:
     paths:
       - ".github/workflows/check-mkdocs-task.ya?ml"
       - "**/.npmrc"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "mkdocs.ya?ml"
       - "package.json"
@@ -81,7 +81,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
 name: Deploy Website
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 on:
   push:
     branches:
@@ -69,7 +65,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-integration-task.md
 name: Test Integration
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -81,7 +77,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-task.md
 name: Test Go
 
-env:
-  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.22"
-
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
@@ -91,7 +87,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -19,7 +19,7 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.22.5"
+  GO_VERSION: "1.22.9"
 
 tasks:
   Windows_32bit:
@@ -131,11 +131,12 @@ tasks:
     desc: Builds Linux ARMv6 binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=0 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
+        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
@@ -172,7 +173,7 @@ tasks:
       #
       # Until there is a fix released we must use a recent gcc for Linux_ARMv6 build, so for this
       # build we select the debian10 based container.
-      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian9"
+      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian12"
       PACKAGE_PLATFORM: "Linux_ARMv6"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 

--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -1,7 +1,7 @@
 // Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/cobra/docsgen/go.mod
 module github.com/arduino/arduino-lint/docsgen
 
-go 1.22.3
+go 1.22.9
 
 replace github.com/arduino/arduino-lint => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-lint
 
-go 1.22.3
+go 1.22.9
 
 replace github.com/jandelgado/gcov2lcov => github.com/jandelgado/gcov2lcov v1.0.5 // v1.0.4 causes Dependabot updates to fail due to checksum mismatch (likely a moved tag). This is an unused transitive dependency, so version is irrelevant.
 

--- a/ruledocsgen/go.mod
+++ b/ruledocsgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-lint/ruledocsgen
 
-go 1.22.3
+go 1.22.9
 
 replace github.com/arduino/arduino-lint => ../
 


### PR DESCRIPTION
Go is used in the development and maintenance of the project. A standardized version of Go is used for all operations.

This version is defined in the [`go` directive](https://go.dev/ref/mod#go-mod-file-go) of the `go.mod` metadata file.

Go is installed in the GitHub Actions runner environments using the **actions/setup-go** action, which also must be configured to install the correct version of Go. Previously the version number for use by the **actions/setup-go** action was defined in each workflow. This meant that we had multiple copies of the Go version information, all of which had to be kept in sync.

Fortunately, support for using `go.mod` as the source of version information for the **actions/setup-go** action was recently added:

https://github.com/actions/setup-go/tree/main#getting-go-version-from-the-gomod-file

This means it is now possible for all workflows to get the Go version from a single source.