### PR TITLE
Reference canonical Python version info source in contributor guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,7 +81,9 @@ To build Arduino Lint from sources you need the following tools to be available 
 
 If you want to run integration tests or work on documentation, you will also need:
 
-- A working [Python](https://www.python.org/downloads/) environment, version 3.9 or later.
+- A working [Python](https://www.python.org/downloads/) environment.
+  - The **Python** version in use is defined in the `tool.poetry.dependencies` field of
+    [`pyproject.toml`](https://github.com/arduino/arduino-lint/blob/main/pyproject.toml).
 - [Poetry](https://python-poetry.org/docs/).
 - [**Node.js** / **npm**](https://nodejs.org/en/download/) - Node.js dependencies management tool.
   - The **Node.js** version in use is defined in the `engines.node` field of


### PR DESCRIPTION
Python and Python-based tools are used in the development and maintenance of the project. A standardized version of Python is used for these operations. The contributor will need to have this version installed if they want to perform the dependent operations. For this reason, the dependency on Python and the standardized version is documented in the contributor guide.

Poetry is used for Python package dependencies management. Poetry installs dependencies into a virtual environment. For this reason, the Poetry configuration includes a Python version number, which must match the correct version of Python for the project. This configuration is stored in the `pyproject.toml` file. This is also used as the source of Python versioning information by all other parts of the infrastructure (https://github.com/arduino/arduino-lint/pull/799).

In order to avoid the need to maintain an additional copy of that information in the contributor guide, it will be beneficial to instead direct the contributor to obtain the version info from the `pyproject.toml` file.