### PR TITLE
Only download required artifact in notarization job of release workflows

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -100,8 +100,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_PREFIX }}*
-          merge-multiple: true
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -109,8 +109,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ env.ARTIFACT_PREFIX }}*
-          merge-multiple: true
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates


### PR DESCRIPTION
GitHub Workflows are used to automatically generate and publish production and nightly releases of the project. This is done for a range of host architectures, including macOS. The macOS builds are then put through a notarization process in a dedicated workflow job.

GitHub Actions workflow artifacts are used to transfer the generated files between sequential jobs in the workflow. The builds are transferred between jobs by GitHub Actions workflow artifacts, one for each host architecture.

Previously, the "notarize-macos" job matrix that performs the notarization unnecessarily downloaded all the build artifacts, even though each job only requires the relevant macOS artifact. This is inefficient.

The better approach is to configure the "notarize-macos" jobs to only download the artifact they require.