### PR TITLE
github: Use IAM Roles to push files on AWS S3

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -7,7 +7,8 @@ env:
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: /arduino-lint/
+  AWS_PLUGIN_TARGET: /arduino-lint/nightly/
+  AWS_REGION: "us-east-1"
   ARTIFACT_PREFIX: dist-
 
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
@@ -183,8 +184,11 @@ jobs:
 
   publish-nightly:
     runs-on: ubuntu-latest
+    environment: production
     needs: notarize-macos
-    permissions: {}
+    permissions:
+      contents: write
+      id-token: write # This is required for requesting the JWT
 
     steps:
       - name: Download artifact
@@ -200,15 +204,15 @@ jobs:
           TAG="nightly-$(date -u +"%Y%m%d")"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}nightly
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -7,7 +7,7 @@ env:
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: /arduino-lint/nightly/
+  AWS_PLUGIN_TARGET: /arduino-lint/
   AWS_REGION: "us-east-1"
   ARTIFACT_PREFIX: dist-
 

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -13,6 +13,7 @@ env:
 
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
+  push:
   schedule:
     # run every day at 1AM
     - cron: "0 1 * * *"

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -13,7 +13,6 @@ env:
 
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
-  push:
   schedule:
     # run every day at 1AM
     - cron: "0 1 * * *"

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -8,6 +8,7 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduino-lint/
+  AWS_REGION: "us-east-1"
   ARTIFACT_PREFIX: dist-
 
 on:
@@ -189,9 +190,11 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
+    environment: production
     needs: notarize-macos
     permissions:
       contents: write
+      id-token: write # This is required for requesting the JWT
 
     steps:
       - name: Download artifact
@@ -235,12 +238,12 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}


### PR DESCRIPTION
For security reasons long lived credentials are not considered secure.
To overcome this issue we can configure Github Workflows to use AWS OpenID Connect instead:
For further details: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

Tested:
- [x] Release: https://github.com/arduino/arduino-lint/actions/runs/12297322664
- [x] Nightly: https://github.com/arduino/arduino-lint/actions/runs/12297785410/job/34319921983
- [x] Removed old secrets `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`