### PR TITLE
Remove inappropriate dependency license exception entries from Licensed configuration

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -7,15 +7,6 @@ apps:
   - source_path: docsgen/
   - source_path: ruledocsgen/
 
-reviewed:
-  go:
-    - github.com/klauspost/compress
-    - github.com/klauspost/compress/fse
-    - github.com/klauspost/compress/huff0
-    - github.com/klauspost/compress/internal/cpuinfo
-    - github.com/klauspost/compress/internal/snapref
-    - github.com/klauspost/compress/zstd
-
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
 allowed:
   # The following are based on: https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses

--- a/.licenses/arduino-lint/go/github.com/klauspost/compress.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/klauspost/compress.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/klauspost/compress
-license: other
+license: bsd-3-clause
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/klauspost/compress/fse.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/klauspost/compress/fse.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package fse provides Finite State Entropy encoding and decoding.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/fse
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/klauspost/compress/huff0.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/klauspost/compress/huff0.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: This file contains the specialisation of Decoder.Decompress4X and Decoder.Decompress1X
   that use an asm implementation of thir main loops.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/huff0
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/klauspost/compress/internal/cpuinfo.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/klauspost/compress/internal/cpuinfo.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package cpuinfo gives runtime info about the current CPU.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/internal/cpuinfo
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/klauspost/compress/internal/snapref.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/klauspost/compress/internal/snapref.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package snapref implements the Snappy compression format.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/internal/snapref
-license: other
+license: bsd-3-clause
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/klauspost/compress/zstd.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/klauspost/compress/zstd.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package zstd provides decompression of zstandard files.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/zstd
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/klauspost/compress/zstd/internal/xxhash.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/klauspost/compress/zstd/internal/xxhash.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/klauspost/compress/zstd/internal/xxhash
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/klauspost/compress.dep.yml
+++ b/.licenses/docsgen/go/github.com/klauspost/compress.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/klauspost/compress
-license: other
+license: bsd-3-clause
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/klauspost/compress/fse.dep.yml
+++ b/.licenses/docsgen/go/github.com/klauspost/compress/fse.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package fse provides Finite State Entropy encoding and decoding.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/fse
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/klauspost/compress/huff0.dep.yml
+++ b/.licenses/docsgen/go/github.com/klauspost/compress/huff0.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: This file contains the specialisation of Decoder.Decompress4X and Decoder.Decompress1X
   that use an asm implementation of thir main loops.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/huff0
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/klauspost/compress/internal/cpuinfo.dep.yml
+++ b/.licenses/docsgen/go/github.com/klauspost/compress/internal/cpuinfo.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package cpuinfo gives runtime info about the current CPU.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/internal/cpuinfo
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/klauspost/compress/internal/snapref.dep.yml
+++ b/.licenses/docsgen/go/github.com/klauspost/compress/internal/snapref.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package snapref implements the Snappy compression format.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/internal/snapref
-license: other
+license: bsd-3-clause
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/klauspost/compress/zstd.dep.yml
+++ b/.licenses/docsgen/go/github.com/klauspost/compress/zstd.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package zstd provides decompression of zstandard files.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/zstd
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/klauspost/compress/zstd/internal/xxhash.dep.yml
+++ b/.licenses/docsgen/go/github.com/klauspost/compress/zstd/internal/xxhash.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/klauspost/compress/zstd/internal/xxhash
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/klauspost/compress.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/klauspost/compress.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/klauspost/compress
-license: other
+license: bsd-3-clause
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/klauspost/compress/fse.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/klauspost/compress/fse.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package fse provides Finite State Entropy encoding and decoding.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/fse
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/klauspost/compress/huff0.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/klauspost/compress/huff0.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: This file contains the specialisation of Decoder.Decompress4X and Decoder.Decompress1X
   that use an asm implementation of thir main loops.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/huff0
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/klauspost/compress/internal/cpuinfo.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/klauspost/compress/internal/cpuinfo.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package cpuinfo gives runtime info about the current CPU.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/internal/cpuinfo
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/klauspost/compress/internal/snapref.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/klauspost/compress/internal/snapref.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package snapref implements the Snappy compression format.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/internal/snapref
-license: other
+license: bsd-3-clause
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/klauspost/compress/zstd.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/klauspost/compress/zstd.dep.yml
@@ -4,7 +4,7 @@ version: v1.17.0
 type: go
 summary: Package zstd provides decompression of zstandard files.
 homepage: https://pkg.go.dev/github.com/klauspost/compress/zstd
-license: other
+license: bsd-3-clause
 licenses:
 - sources: compress@v1.17.0/LICENSE
   text: |


### PR DESCRIPTION
The [**Licensed**](https://github.com/github/licensed) tool is used to check for incompatible licenses in the project dependencies. The tool can be configured to ignore incompatible license types for specific dependencies. This is done by adding an entry for the dependency to the `reviewed` entry in the **Licensed** configuration file.

Such exceptions should be added only when the project maintainer has determined the following things to be true:

- dependency license is not one of the standard compatible types (as defined by the `allowed` mapping in the config)
- dependency license is compatible with the licensing of the project (e.g., dependency uses a non-standard but compatible license)

**Licensed** uses the [**licensee**](https://github.com/licensee/licensee) tool to automatically determine the license type based on metadata provided by the dependency author. This metadata must be in a standardized format without any modifications. In cases where that wasn't done, "Licensed" will identify the license type as "other". In this case, the project maintainer must manually determine the license type. If the license is determined to have a standard type, then the maintainer must manually set the correct license type in the license cache metadata for the dependency. The dependency exception system should not be used in this case.

Exceptions were inappropriately set up for dependencies with compatible license types not automatically identifiable by **Licensed**/**licensee** (https://github.com/arduino/arduino-lint/pull/761). These exceptions are hereby removed from the **Licensed** configuration file and the manually determined license types defined in the license metadata cache for the dependencies.