### PR TITLE
Manually define dependency license type metadata not automatically specified

### DIFF
--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/cores.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/cores.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/cores
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/cores/packageindex.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/cores/packageindex.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/cores/packageindex
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/globals.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/globals.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/globals
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/httpclient.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/httpclient.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/httpclient
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/libraries.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/libraries.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/libraries/librariesindex.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/libraries/librariesindex.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries/librariesindex
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/resources.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/resources.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/resources
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/security.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/security.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/security
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/sketch.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/sketch.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/sketch
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/utils.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/arduino/utils.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/utils
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/configuration.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/configuration.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/configuration
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/i18n.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/i18n.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/i18n
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/internal/cli/feedback.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/internal/cli/feedback.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: Package feedback provides an uniform API that can be used to print feedback
   to the users in different formats.
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/internal/cli/feedback
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/version.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/arduino/arduino-cli/version.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/version
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary: Package toml is a library to read and write TOML documents.
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/characters
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/danger
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/tracker
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/unstable.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/pelletier/go-toml/v2/unstable.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: Package unstable provides APIs that do not meet the backward compatibility
   guarantees yet.
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/cores.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/cores.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/cores
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/cores/packageindex.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/cores/packageindex.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/cores/packageindex
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/globals.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/globals.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/globals
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/httpclient.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/httpclient.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/httpclient
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/libraries.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/libraries.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesindex.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesindex.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries/librariesindex
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/resources.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/resources.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/resources
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/security.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/security.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/security
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/sketch.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/sketch.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/sketch
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/utils.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/arduino/utils.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/utils
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/configuration.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/configuration.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/configuration
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/i18n.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/i18n.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/i18n
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/internal/cli/feedback.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/internal/cli/feedback.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: Package feedback provides an uniform API that can be used to print feedback
   to the users in different formats.
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/internal/cli/feedback
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/arduino/arduino-cli/version.dep.yml
+++ b/.licenses/docsgen/go/github.com/arduino/arduino-cli/version.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/version
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/docsgen/go/github.com/pelletier/go-toml/v2.dep.yml
+++ b/.licenses/docsgen/go/github.com/pelletier/go-toml/v2.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary: Package toml is a library to read and write TOML documents.
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
+++ b/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/characters
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
+++ b/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/danger
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
+++ b/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/tracker
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/unstable.dep.yml
+++ b/.licenses/docsgen/go/github.com/pelletier/go-toml/v2/unstable.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: Package unstable provides APIs that do not meet the backward compatibility
   guarantees yet.
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/cores.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/cores.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/cores
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/cores/packageindex.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/cores/packageindex.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/cores/packageindex
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/globals.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/globals.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/globals
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/httpclient.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/httpclient.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/httpclient
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/libraries.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/libraries.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesindex.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesindex.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries/librariesindex
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/libraries/librariesmanager
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/resources.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/resources.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/resources
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/security.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/security.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/security
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/sketch.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/sketch.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/sketch
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/utils.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/arduino/utils.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/arduino/utils
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/configuration.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/configuration.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/configuration
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/i18n.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/i18n.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/i18n
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/internal/cli/feedback.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/internal/cli/feedback.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: Package feedback provides an uniform API that can be used to print feedback
   to the users in different formats.
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/internal/cli/feedback
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/version.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/arduino/arduino-cli/version.dep.yml
@@ -4,7 +4,7 @@ version: v0.35.4-0.20241001142927-1f8d0f6c0dd3
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/arduino/arduino-cli/version
-license: other
+license: gpl-3.0-only
 licenses:
 - sources: arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/LICENSE.txt
   text: |2

--- a/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary: Package toml is a library to read and write TOML documents.
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/characters
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/danger
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
@@ -4,7 +4,7 @@ version: v2.1.0
 type: go
 summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/tracker
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |

--- a/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/unstable.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/pelletier/go-toml/v2/unstable.dep.yml
@@ -5,7 +5,7 @@ type: go
 summary: Package unstable provides APIs that do not meet the backward compatibility
   guarantees yet.
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable
-license: other
+license: mit
 licenses:
 - sources: v2@v2.1.0/LICENSE
   text: |


### PR DESCRIPTION
## Background

The [**Licensed**](https://github.com/github/licensed) dependency license checker tool uses the [**licensee**](https://github.com/licensee/licensee) gem to automatically determine the license type based on data contained in the dependency codebase. **licensee** checks several files for this data. The discovered data is recorded in the `licenses` sequence of the [dependency license metadata cache](https://github.com/github/licensed/blob/main/docs/configuration/metadata_cache.md) file. It might find multiple sources of licensing data. The way **Licensed** handles this case is described as:

https://github.com/github/licensed/blob/v5.0.1/docs/commands/status.md#checking-status-with-metadata-loaded-from-cached-files

> If `license: other` is specified and all of the `licenses` entries match an `allowed` license a failure will not be logged

It is of course correct to treat the dependency as compatible under these conditions. However, the design of **Licensed** around the handling of multiple licensing data sources is not very user friendly:

### Lack of Transparency Re: Detected License Type

Even though **Licensed** knows exactly which license type each of the sources was detected as, it does not record this data in the dependency license metadata cache file.

### Ambiguous Special License Type Identifier

When multiple license data sources are found, **Licensed** sets the license type for the dependency to `other` in the `license` key of the dependency license metadata cache file.

Although it is correct for the tool to use a special identifier, unfortunately "Licensed" uses the same identifier for two significantly different cases:

- license type was not identifiable from the data (e.g., modifications were made to standard license text)
- multiple license types were identified from the data

The better approach would be for **Licensed** to use a separate identifier for each of these situations (e.g., `other`, `multi`).

### Failure to Set License Type Even when Identified

Even when all of the multiple data sources are identified as the same license type, "Licensed" still unnecessarily sets the `license` key of the dependency license metadata cache file to `other` instead of setting it to the identifier of the identified license.

## Problem

Project maintainers expect that an identified license type of `other` means that the license type could not be identified and that they must [manually identify and set the license type](https://github.com/github/licensed/blob/v5.0.1/docs/commands/status.md#:~:text=If%20the%20cached%20license%20text%20is%20recognizable%20with%20human%20review%20then%20update%20the%20license%3A%20other%20value%20in%20the%20cached%20metadata%20file%20to%20the%20correct%20license) in order for the compliance check to pass. They will be extremely concerned to find that the check is passing even though a dependency's license type is defined as `other`, as this appears to be a false negative (meaning that the system is not effectively enforcing compliance).

The ambiguous special license type identifier and lack of information about the detected type of individual license data sources will make it impossible for them to understand why the check is passing despite the lack of a defined compatible license type, and so they will waste time troubleshooting what is actually a completely functional system.

## Resolution

Always define the license type in the metadata cache, even when doing so is not required to get a passing check.

In this case, all the dependencies previously assigned the `other` identifier due to having multiple license data sources actually had a single license type. So this was [handled just the same as is done when a dependency is assigned an `other` identifier due to the license data not being machine identifiable](https://github.com/github/licensed/blob/v5.0.1/docs/commands/status.md#:~:text=If%20the%20cached%20license%20text%20is%20recognizable%20with%20human%20review%20then%20update%20the%20license%3A%20other%20value%20in%20the%20cached%20metadata%20file%20to%20the%20correct%20license).