### PR TITLE
Use latest version of "github/setup-licensed" action

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -75,7 +75,7 @@ jobs:
           ruby-version: ruby # Install latest version
 
       - name: Install licensed
-        uses: github/setup-licensed@v1
+        uses: github/setup-licensed@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: 5.x


### PR DESCRIPTION
The [**github/setup-licensed**](https://github.com/github/setup-licensed) action is used by the dependencies license check workflow to install the [**Licensed**](https://github.com/github/licensed) tool in the runner machine.

Previously the `v1` [major version ref](https://docs.github.com/actions/sharing-automations/creating-actions/about-custom-actions#good-practices-for-release-management) of the action was specified in the workflow. This approach is used in order to allow the workflow to automatically always use the latest minor version of the action, only requiring the project maintainers to perform a bump of the action after each major version release.

In a competently maintained action project, the major version ref will be updated after each release within that major version series so that it always points to the latest release version. Unfortunately that was not done by the **github/setup-licensed** action maintainers. This means that the use of the `v1` ref in the workflow causes an outdated version of the action to be used. This has been reported to the action maintainers (https://github.com/github/setup-licensed/issues/304), but unfortunately instead of fixing the problem they archived the repository, so there is no hope of it being resolved.

The solution is to replace the major version ref with the ref for the [latest release](https://github.com/github/setup-licensed/releases/latest) tag. This won't result in an increased maintenance burden because the action repository is archived and thus there won't be any bumps.