### PR TITLE
Bump "Licensed" version in dependency license check workflow

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -137,7 +137,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
The version of the "Licensed" tool for use in the GitHub Actions workflow is defined via the "licensee/setup-licensed" action's `version` input.

The workflow contains two jobs that use the action.

Previously (https://github.com/arduino/arduino-lint/pull/837), the action was configured to install the latest version of Licensed in one job, but by accident the update was performed in the other job, leaving it using the significantly outdated version 3.x of the action.

The workflow is hereby updated to use the latest version of Licensed in all jobs.