### PR TITLE
Configure Dependabot to check for updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,8 @@ updates:
       - per1234
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
 
@@ -21,7 +22,8 @@ updates:
       - per1234
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
   - package-ecosystem: gomod
@@ -30,7 +32,8 @@ updates:
       - per1234
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
   - package-ecosystem: gomod
@@ -39,7 +42,8 @@ updates:
       - per1234
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
 
@@ -49,7 +53,8 @@ updates:
       - per1234
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
 
@@ -59,6 +64,7 @@ updates:
       - per1234
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"


### PR DESCRIPTION
Dependabot is used to keep the project dependencies updated. Dependabot periodically checks for available updates, and if found submits a pull request.

The frequency of the update checks is configurable. Despite the name, the "daily" schedule configuration previously used actually only runs on weekdays. Maintenance of open source software projects is not necessarily limited to weekdays (and in the case of volunteer projects, is more likely to occur on weekends). So the weekday-ly update checks tended to result in a concentration of Dependabot pull requests on Mondays. This unnecessarily added to the busyness of an already busy day.