### PR TITLE
Avoid excessive indentation in shell commands

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -100,7 +100,9 @@ jobs:
               -legacy \
               -noout \
               -passin env:CERTIFICATE_PASSWORD
-          ) || (
+          ) \
+          || \
+          (
             echo "::error::Verification of ${{ matrix.certificate.identifier }} failed!!!"
             exit 1
           )
@@ -124,39 +126,45 @@ jobs:
         run: |
           if [[ ${{ matrix.certificate.type }} == "pkcs12" ]]; then
             EXPIRATION_DATE="$(
-                (
+              (
                 openssl pkcs12 \
-                    -in ${{ env.CERTIFICATE_PATH }} \
-                    -clcerts \
-                    -legacy \
-                    -nodes \
-                    -passin env:CERTIFICATE_PASSWORD
-                ) | (
+                  -in ${{ env.CERTIFICATE_PATH }} \
+                  -clcerts \
+                  -legacy \
+                  -nodes \
+                  -passin env:CERTIFICATE_PASSWORD
+              ) \
+              | \
+              (
                 openssl x509 \
-                    -noout \
-                    -enddate
-                ) | (
+                  -noout \
+                  -enddate
+              ) \
+              | \
+              (
                 grep \
-                    --max-count=1 \
-                    --only-matching \
-                    --perl-regexp \
-                    'notAfter=(\K.*)'
-                )
+                  --max-count=1 \
+                  --only-matching \
+                  --perl-regexp \
+                  'notAfter=(\K.*)'
+              )
             )"
           elif [[ ${{ matrix.certificate.type }} == "x509" ]]; then
             EXPIRATION_DATE="$(
-                (
+              (
                 openssl x509 \
-                    -in ${{ env.CERTIFICATE_PATH }} \
-                    -noout \
-                    -enddate
-                ) | (
+                  -in ${{ env.CERTIFICATE_PATH }} \
+                  -noout \
+                  -enddate
+              ) \
+              | \
+              (
                 grep \
-                    --max-count=1 \
-                    --only-matching \
-                    --perl-regexp \
-                    'notAfter=(\K.*)'
-                )
+                  --max-count=1 \
+                  --only-matching \
+                  --perl-regexp \
+                  'notAfter=(\K.*)'
+              )
             )"
           fi
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,9 +12,11 @@ vars:
   DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES: |
     $( \
-      go list ./... | \
-        grep --invert-match 'github.com/arduino/arduino-lint/internal/rule/schema/schemadata' | \
-          tr '\n' ' ' \
+      go list ./... \
+      | \
+      grep --invert-match 'github.com/arduino/arduino-lint/internal/rule/schema/schemadata' \
+      | \
+      tr '\n' ' ' \
       || \
       echo '"ERROR: Unable to discover Go packages"' \
     )
@@ -589,9 +591,9 @@ tasks:
     cmds:
       - |
         if [[ "{{.OS}}" == "Windows_NT" ]] && which cygpath &>/dev/null; then
-            # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
-            # So paths passed to such applications must first be converted to Windows format.
-            cygpath -w "{{.RAW_PATH}}"
+          # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
+          # So paths passed to such applications must first be converted to Windows format.
+          cygpath -w "{{.RAW_PATH}}"
         else
           echo "{{.RAW_PATH}}"
         fi


### PR DESCRIPTION
The project's GitHub Actions workflows and tasks contain complex shell command lines.

With the use of the line continuation operator, these commands can be split into multiple code lines. This improves readability by providing a visualization of the command structure. It also improves maintainability by making diffs for changes to these commands more clear.

The readability can be further improved by indentation of the subsequent lines of the command in a manner that visually conveys the structure.

Previously, in cases where multiple commands are chained via control or list operators, the subsequent commands were indented relative to the prior command in the chain. Although this did help to visually convey the structure, it also resulted in excessive levels of indentation. It also resulted in some visual ambiguity between indentation used for arguments to a command, and that for subsequent commands in the chain. For these reasons, the determination was made to not indent the subsequent commands in the chain. The structure is communicated by placing the operator linking the commands on a dedicated line.