### PR TITLE
Split shell commands into multiple lines for readability

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -88,7 +88,11 @@ jobs:
         env:
           CERTIFICATE: ${{ secrets[matrix.certificate.certificate-secret] }}
         run: |
-          echo "${{ env.CERTIFICATE }}" | base64 --decode > "${{ env.CERTIFICATE_PATH }}"
+          echo "${{ env.CERTIFICATE }}" \
+          | \
+          base64 \
+            --decode \
+          >"${{ env.CERTIFICATE_PATH }}"
 
       - name: Verify certificate
         env:
@@ -168,7 +172,9 @@ jobs:
             )"
           fi
 
-          DAYS_BEFORE_EXPIRATION="$((($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24))"
+          DAYS_BEFORE_EXPIRATION="$(
+            (($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24)
+          )"
 
           # Display the expiration information in the log.
           echo "Certificate expiration date: $EXPIRATION_DATE"

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -71,12 +71,19 @@ jobs:
       - name: Install editorconfig-checker
         run: |
           cd "${{ env.EC_INSTALL_PATH }}"
-          tar --extract --file="${{ steps.download.outputs.name }}"
+          tar \
+            --extract \
+            --file="${{ steps.download.outputs.name }}"
           # Give the binary a standard name
-          mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
+          mv \
+            "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" \
+            "${{ env.EC_INSTALL_PATH }}/bin/ec"
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.EC_INSTALL_PATH }}/bin" >>"$GITHUB_PATH"
 
       - name: Check formatting
-        run: task --silent general:check-formatting
+        run: |
+          task \
+            --silent \
+            general:check-formatting

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -92,13 +92,21 @@ jobs:
           version: 3.x
 
       - name: Update dependencies license metadata cache
-        run: task --silent general:cache-dep-licenses
+        run: |
+          task \
+            --silent \
+            general:cache-dep-licenses
 
       - name: Check for outdated cache
         id: diff
         run: |
           git add .
-          if ! git diff --cached --color --exit-code; then
+          if
+            ! git diff \
+              --cached \
+              --color \
+              --exit-code
+          then
             echo
             echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
             exit 1
@@ -151,4 +159,7 @@ jobs:
           version: 3.x
 
       - name: Check for dependencies with unapproved licenses
-        run: task --silent general:check-dep-licenses
+        run: |
+          task \
+            --silent \
+            general:check-dep-licenses

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -124,7 +124,10 @@ jobs:
         run: task go:fix
 
       - name: Check if any fixes were needed
-        run: git diff --color --exit-code
+        run: |
+          git diff \
+            --color \
+            --exit-code
 
   check-style:
     name: check-style (${{ matrix.module.path }})
@@ -164,7 +167,10 @@ jobs:
       - name: Check style
         env:
           GO_MODULE_PATH: ${{ matrix.module.path }}
-        run: task --silent go:lint
+        run: |
+          task \
+            --silent \
+            go:lint
 
   check-formatting:
     name: check-formatting (${{ matrix.module.path }})
@@ -204,7 +210,10 @@ jobs:
         run: task go:format
 
       - name: Check formatting
-        run: git diff --color --exit-code
+        run: |
+          git diff \
+            --color \
+            --exit-code
 
   check-config:
     name: check-config (${{ matrix.module.path }})
@@ -244,4 +253,7 @@ jobs:
         run: task go:tidy
 
       - name: Check whether any tidying was needed
-        run: git diff --color --exit-code
+        run: |
+          git diff \
+            --color \
+            --exit-code

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -80,7 +80,9 @@ jobs:
           ruby-version: ruby # Install latest version
 
       - name: Install licensee
-        run: gem install licensee
+        run: |
+          gem install \
+            licensee
 
       - name: Check license file for ${{ matrix.check-license.path }}
         run: |
@@ -92,14 +94,26 @@ jobs:
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 
-          DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
+          DETECTED_LICENSE_FILE="$(
+            echo "$LICENSEE_OUTPUT" \
+            | \
+            jq .matched_files[0].filename \
+            | \
+            tr --delete '\r'
+          )"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
           if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.expected-filename }}\"" ]; then
             echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.expected-filename }}"
             EXIT_STATUS=1
           fi
 
-          DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
+          DETECTED_LICENSE_TYPE="$(
+            echo "$LICENSEE_OUTPUT" \
+            | \
+            jq .matched_files[0].matched_license \
+            | \
+            tr --delete '\r'
+          )"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
           if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.expected-type }}\"" ]; then
             echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.expected-type }}\""

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -121,4 +121,7 @@ jobs:
           version: 3.x
 
       - name: Check links
-        run: task --silent markdown:check-links
+        run: |
+          task \
+            --silent \
+            markdown:check-links

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -79,7 +79,11 @@ jobs:
           version: 3.x
 
       - name: Validate package.json
-        run: task --silent npm:validate PROJECT_PATH="${{ matrix.project.path }}"
+        run: |
+          task \
+            --silent \
+            npm:validate \
+            PROJECT_PATH="${{ matrix.project.path }}"
 
   check-sync:
     name: check-sync (${{ matrix.project.path }})
@@ -112,7 +116,13 @@ jobs:
           version: 3.x
 
       - name: Install npm dependencies
-        run: task npm:install-deps PROJECT_PATH="${{ matrix.project.path }}"
+        run: |
+          task npm:install-deps \
+            PROJECT_PATH="${{ matrix.project.path }}"
 
       - name: Check package-lock.json
-        run: git diff --color --exit-code "${{ matrix.project.path }}/package-lock.json"
+        run: |
+          git diff \
+            --color \
+            --exit-code \
+            "${{ matrix.project.path }}/package-lock.json"

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -255,4 +255,7 @@ jobs:
         run: task general:format-prettier
 
       - name: Check formatting
-        run: git diff --color --exit-code
+        run: |
+          git diff \
+            --color \
+            --exit-code

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -115,4 +115,7 @@ jobs:
         run: task python:format
 
       - name: Check formatting
-        run: git diff --color --exit-code
+        run: |
+          git diff \
+            --color \
+            --exit-code

--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -105,7 +105,9 @@ jobs:
       - name: Install ShellCheck
         run: |
           cd "${{ env.INSTALL_PATH }}"
-          tar --extract --file="${{ steps.download.outputs.name }}"
+          tar \
+            --extract \
+            --file="${{ steps.download.outputs.name }}"
           EXTRACTION_FOLDER="$(
             basename \
               "${{ steps.download.outputs.name }}" \
@@ -167,9 +169,13 @@ jobs:
       - name: Install shfmt
         run: |
           # Executable permissions of release assets are lost
-          chmod +x "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}"
+          chmod \
+            +x \
+            "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}"
           # Standardize binary name
-          mv "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
+          mv \
+            "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" \
+            "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.SHFMT_INSTALL_PATH }}" >>"$GITHUB_PATH"
@@ -182,7 +188,10 @@ jobs:
             SCRIPT_PATH="${{ matrix.script }}"
 
       - name: Check formatting
-        run: git diff --color --exit-code
+        run: |
+          git diff \
+            --color \
+            --exit-code
 
   executable:
     name: executable (${{ matrix.script }})

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -45,4 +45,7 @@ jobs:
           version: 3.x
 
       - name: Validate workflows
-        run: task --silent ci:validate
+        run: |
+          task \
+            --silent \
+            ci:validate

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -102,17 +102,22 @@ jobs:
         if: fromJson(steps.determine-versioning.outputs.data).version != null
         run: |
           # Publishing implies creating a git commit on the gh-pages branch, we let @ArduinoBot own these commits.
-          git config --global user.email "bot@arduino.cc"
-          git config --global user.name "ArduinoBot"
+          git config \
+            --global \
+            user.email "bot@arduino.cc"
+          git config \
+            --global \
+            user.name "ArduinoBot"
           git fetch \
             --no-tags \
             --prune \
             --depth=1 \
             origin \
             +refs/heads/gh-pages:refs/remotes/origin/gh-pages
-          poetry run mike deploy \
-            --update-aliases \
-            --push \
-            --remote origin \
-            ${{ fromJson(steps.determine-versioning.outputs.data).version }} \
-            ${{ fromJson(steps.determine-versioning.outputs.data).alias }}
+          poetry run \
+            mike deploy \
+              --update-aliases \
+              --push \
+              --remote origin \
+              ${{ fromJson(steps.determine-versioning.outputs.data).version }} \
+              ${{ fromJson(steps.determine-versioning.outputs.data).alias }}

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -112,9 +112,14 @@ jobs:
           KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode >"${{ env.INSTALLER_CERT_MAC_PATH }}"
-          security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
-          security default-keychain -s "${{ env.KEYCHAIN }}"
-          security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security create-keychain \
+            -p "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
+          security default-keychain \
+            -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain \
+            -p "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
           security import \
             "${{ env.INSTALLER_CERT_MAC_PATH }}" \
             -k "${{ env.KEYCHAIN }}" \
@@ -130,13 +135,18 @@ jobs:
 
       - name: Install gon for code signing and app notarization
         run: |
-          wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
-          unzip gon_macos.zip -d /usr/local/bin
+          wget \
+            -q \
+            https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
 
+          unzip \
+            gon_macos.zip \
+            -d /usr/local/bin
       - name: Write gon config to file
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
-          cat >"${{ env.GON_CONFIG_PATH }}" <<EOF
+          cat >"${{ env.GON_CONFIG_PATH }}" \
+          <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
           source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
@@ -166,12 +176,17 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
+          chmod \
+            +x \
+            "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
           # Use of an array here is required for globbing
           PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_nightly-*${{ matrix.build.package-suffix }})
-          tar -czvf "$PACKAGE_FILENAME" \
-            -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
-            -C ../../ LICENSE.txt
+          tar \
+            -czvf "$PACKAGE_FILENAME" \
+            -C "${{ env.BUILD_FOLDER }}/" \
+            "${{ env.PROJECT_NAME }}" \
+            -C ../../ \
+            LICENSE.txt
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Replace artifact with notarized build
@@ -212,7 +227,10 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload release files on Arduino downloads servers
-        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}nightly
+        run: |
+          aws s3 sync \
+            ${{ env.DIST_DIR }} \
+            s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}nightly
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -151,7 +151,9 @@ jobs:
       - name: Create checksum file
         run: |
           TAG="${{ needs.package-name-prefix.outputs.prefix }}git-snapshot"
-          declare -a artifacts=($(ls -d */))
+          declare \
+            -a \
+            artifacts=($(ls -d */))
           for artifact in ${artifacts[@]}; do
             cd $artifact
             checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -121,9 +121,14 @@ jobs:
           KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode >"${{ env.INSTALLER_CERT_MAC_PATH }}"
-          security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
-          security default-keychain -s "${{ env.KEYCHAIN }}"
-          security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security create-keychain \
+            -p "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
+          security default-keychain \
+            -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain \
+            -p "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
           security import \
             "${{ env.INSTALLER_CERT_MAC_PATH }}" \
             -k "${{ env.KEYCHAIN }}" \
@@ -139,9 +144,12 @@ jobs:
 
       - name: Install gon for code signing and app notarization
         run: |
-          wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
-          unzip gon_macos.zip -d /usr/local/bin
+          wget \
+            -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
 
+          unzip \
+            gon_macos.zip \
+            -d /usr/local/bin
       - name: Write gon config to file
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
@@ -175,11 +183,15 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
-          tar -czvf "${{ env.PACKAGE_FILENAME }}" \
-          -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
-          -C ../../ LICENSE.txt
+          chmod \
+            +x \
+            "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
 
+          tar \
+            -czvf "${{ env.PACKAGE_FILENAME }}" \
+            -C "${{ env.BUILD_FOLDER }}/" \
+            "${{ env.PROJECT_NAME }}" \
+            -C ../../ LICENSE.txt
       - name: Replace artifact with notarized build
         uses: actions/upload-artifact@v4
         with:
@@ -215,8 +227,18 @@ jobs:
         # to implement auto pre-release based on tag
         id: prerelease
         run: |
-          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
-          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          wget \
+            -q \
+            -P /tmp \
+            https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
+          unzip \
+            -p \
+            /tmp/3.2.0.zip \
+            semver-tool-3.2.0/src/semver \
+          >/tmp/semver
+          chmod \
+            +x \
+            /tmp/semver
           if [[ \
             "$(
               /tmp/semver get prerel \
@@ -246,4 +268,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload release files on Arduino downloads servers
-        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}
+        run: |
+          aws s3 sync \
+            ${{ env.DIST_DIR }} \
+            s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Verify installation
         shell: bash
         run: |
-          "${PWD}/bin/${{ env.TOOL_NAME }}" --version
+          "${PWD}/bin/${{ env.TOOL_NAME }}" \
+            --version
 
   bindir:
     permissions: {}
@@ -73,13 +74,16 @@ jobs:
       - name: Run script with custom install location
         shell: sh
         run: |
-          mkdir -p "${{ env.BINDIR }}"
+          mkdir \
+            -p \
+            "${{ env.BINDIR }}"
           "${{ github.workspace }}/etc/install.sh"
 
       - name: Verify installation
         shell: bash
         run: |
-          "${{ env.BINDIR }}/${{ env.TOOL_NAME }}" --version
+          "${{ env.BINDIR }}/${{ env.TOOL_NAME }}" \
+            --version
 
   version:
     permissions: {}
@@ -109,7 +113,12 @@ jobs:
       - name: Verify installation
         shell: bash
         run: |
-          "${PWD}/bin/${{ env.TOOL_NAME }}" --version | grep --fixed-strings "${{ env.VERSION }}"
+          "${PWD}/bin/${{ env.TOOL_NAME }}" \
+            --version \
+          | \
+          grep \
+            --fixed-strings \
+            "${{ env.VERSION }}"
 
   nightly:
     permissions: {}
@@ -131,9 +140,14 @@ jobs:
       - name: Run script with nightly build version argument
         shell: sh
         run: |
-          "${{ github.workspace }}/etc/install.sh" "nightly-latest"
+          "${{ github.workspace }}/etc/install.sh" \
+            "nightly-latest"
 
       - name: Verify installation
         shell: bash
         run: |
-          "${PWD}/bin/${{ env.TOOL_NAME }}" --version | grep "^nightly-"
+          "${PWD}/bin/${{ env.TOOL_NAME }}" \
+            --version \
+          | \
+          grep \
+            "^nightly-"

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -27,13 +27,18 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=0 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "{{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
+        zip \
+          {{.PACKAGE_NAME}} \
+          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
+          -j
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
@@ -48,13 +53,18 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=0 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "{{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
+        zip \
+          {{.PACKAGE_NAME}} \
+          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
+          -j
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
@@ -69,13 +79,20 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=0 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "{{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz \
+          -C {{.PLATFORM_DIR}} \
+          {{.PROJECT_NAME}} \
+          -C ../.. \
+          LICENSE.txt \
+          -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
@@ -90,13 +107,20 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=0 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "{{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz \
+          -C {{.PLATFORM_DIR}} \
+          {{.PROJECT_NAME}} \
+          -C ../.. \
+          LICENSE.txt \
+          -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
@@ -111,13 +135,20 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=0 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "{{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz \
+          -C {{.PLATFORM_DIR}} \
+          {{.PROJECT_NAME}} \
+          -C ../.. \
+          LICENSE.txt \
+          -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
@@ -133,13 +164,20 @@ tasks:
     cmds:
       # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=0 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz \
+          -C {{.PLATFORM_DIR}} \
+          {{.PROJECT_NAME}} \
+          -C ../.. \
+          LICENSE.txt \
+          -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
@@ -182,13 +220,20 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=0 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "{{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz \
+          -C {{.PLATFORM_DIR}} \
+          {{.PROJECT_NAME}} \
+          -C ../.. \
+          LICENSE.txt \
+          -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
@@ -204,13 +249,20 @@ tasks:
     cmds:
       # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=1 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz \
+          -C {{.PLATFORM_DIR}} \
+          {{.PROJECT_NAME}} \
+          -C ../.. \
+          LICENSE.txt \
+          -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
@@ -239,13 +291,20 @@ tasks:
     cmds:
       # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=1 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=1 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz \
+          -C {{.PLATFORM_DIR}} \
+          {{.PROJECT_NAME}} \
+          -C ../.. \
+          LICENSE.txt \
+          -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,11 +12,16 @@ vars:
   DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES: |
     $( \
-      go list ./... \
+      go list \
+        ./... \
       | \
-      grep --invert-match 'github.com/arduino/arduino-lint/internal/rule/schema/schemadata' \
+      grep \
+        --invert-match \
+        'github.com/arduino/arduino-lint/internal/rule/schema/schemadata' \
       | \
-      tr '\n' ' ' \
+      tr \
+        '\n' \
+        ' ' \
       || \
       echo '"ERROR: Unable to discover Go packages"' \
     )
@@ -24,13 +29,34 @@ vars:
   SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
   # build vars
   COMMIT:
-    sh: echo "$(git log --no-show-signature -n 1 --format=%h)"
+    sh: |
+      echo \
+        "$(
+          git log \
+            --no-show-signature \
+            -n 1 \
+            --format=%h
+        )"
   TIMESTAMP:
-    sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    sh: |
+      echo \
+        "$(
+          date \
+            -u \
+            +"%Y-%m-%dT%H:%M:%SZ"
+        )"
   TIMESTAMP_SHORT:
     sh: echo "{{now | date "20060102"}}"
   TAG:
-    sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
+    sh: |
+      echo \
+        "$(
+          git tag \
+            --points-at=HEAD \
+          2>/dev/null \
+          | \
+          head -n1
+        )"
   VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
   CONFIGURATION_PACKAGE: "github.com/arduino/{{.PROJECT_NAME}}/internal/configuration"
   LDFLAGS: >-
@@ -188,7 +214,10 @@ tasks:
     desc: Check basic formatting style of all files
     cmds:
       - |
-        if ! which ec &>/dev/null; then
+        if
+          ! which ec \
+          &>/dev/null
+        then
           echo "ec not found or not in PATH."
           echo "Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
           exit 1
@@ -209,7 +238,10 @@ tasks:
     deps:
       - task: poetry:install-deps
     cmds:
-      - poetry run codespell --write-changes
+      - |
+        poetry run \
+          codespell \
+            --write-changes
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
   general:format-prettier:
@@ -217,7 +249,11 @@ tasks:
     deps:
       - task: npm:install-deps
     cmds:
-      - npx prettier --write .
+      - |
+        npx \
+          prettier \
+            --write \
+            .
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
   general:prepare-deps:
@@ -229,7 +265,10 @@ tasks:
     desc: Build the Go code
     dir: "{{.DEFAULT_GO_MODULE_PATH}}"
     cmds:
-      - go build -v {{.LDFLAGS}}
+      - |
+        go build \
+          -v \
+          {{.LDFLAGS}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
   go:cli-docs:
@@ -317,8 +356,14 @@ tasks:
       - task: go:rule-docs:build
       - task: poetry:install-deps
     cmds:
-      - poetry run pytest tests
-      - poetry run pytest ruledocsgen/tests
+      - |
+        poetry run \
+          pytest \
+            tests
+      - |
+        poetry run \
+          pytest \
+            ruledocsgen/tests
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:tidy:
@@ -379,7 +424,11 @@ tasks:
     deps:
       - task: npm:install-deps
     cmds:
-      - npx markdownlint-cli --fix "**/*.md"
+      - |
+        npx \
+          markdownlint-cli \
+            --fix \
+            "**/*.md"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:lint:
@@ -387,7 +436,10 @@ tasks:
     deps:
       - task: npm:install-deps
     cmds:
-      - npx markdownlint-cli "**/*.md"
+      - |
+        npx \
+          markdownlint-cli \
+            "**/*.md"
 
   # Parameter variables:
   # - PROJECT_PATH: path of the npm-managed project. Default value: "./"
@@ -496,7 +548,10 @@ tasks:
     deps:
       - task: poetry:install-deps
     cmds:
-      - poetry run black .
+      - |
+        poetry run \
+          black \
+            .
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-python-task/Taskfile.yml
   python:lint:
@@ -504,7 +559,10 @@ tasks:
     deps:
       - task: poetry:install-deps
     cmds:
-      - poetry run flake8 --show-source
+      - |
+        poetry run \
+          flake8 \
+            --show-source
 
   # Parameter variables:
   # - SCRIPT_PATH: path of the script to be checked.
@@ -590,10 +648,17 @@ tasks:
   utility:normalize-path:
     cmds:
       - |
-        if [[ "{{.OS}}" == "Windows_NT" ]] && which cygpath &>/dev/null; then
+        if
+          [[ "{{.OS}}" == "Windows_NT" ]] \
+          && \
+          which cygpath \
+          &>/dev/null
+        then
           # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
           # So paths passed to such applications must first be converted to Windows format.
-          cygpath -w "{{.RAW_PATH}}"
+          cygpath \
+            -w \
+            "{{.RAW_PATH}}"
         else
           echo "{{.RAW_PATH}}"
         fi
@@ -605,7 +670,10 @@ tasks:
       - task: docs:generate
       - task: poetry:install-deps
     cmds:
-      - poetry run mkdocs build --strict
+      - |
+        poetry run \
+          mkdocs build \
+            --strict
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-mkdocs-task/Taskfile.yml
   website:serve:
@@ -614,4 +682,6 @@ tasks:
       - task: docs:generate
       - task: poetry:install-deps
     cmds:
-      - poetry run mkdocs serve
+      - |
+        poetry run \
+          mkdocs serve


### PR DESCRIPTION
The project's GitHub Actions workflows and tasks contain complex shell command lines.

With the use of the line continuation operator, these commands can be split into multiple code lines. This improves readability by providing a visualization of the command structure and avoiding excessive line lengths. It also improves maintainability by making diffs for changes to these commands more clear.

Previously this was done in many commands, but not consistently throughout the project.