### PR TITLE
Add blank lines to visually group shell command lines

### DIFF
--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -71,13 +71,16 @@ jobs:
       - name: Install editorconfig-checker
         run: |
           cd "${{ env.EC_INSTALL_PATH }}"
+
           tar \
             --extract \
             --file="${{ steps.download.outputs.name }}"
+
           # Give the binary a standard name
           mv \
             "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" \
             "${{ env.EC_INSTALL_PATH }}/bin/ec"
+
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.EC_INSTALL_PATH }}/bin" >>"$GITHUB_PATH"

--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -105,14 +105,17 @@ jobs:
       - name: Install ShellCheck
         run: |
           cd "${{ env.INSTALL_PATH }}"
+
           tar \
             --extract \
             --file="${{ steps.download.outputs.name }}"
+
           EXTRACTION_FOLDER="$(
             basename \
               "${{ steps.download.outputs.name }}" \
               "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}"
           )"
+
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >>"$GITHUB_PATH"
@@ -172,10 +175,12 @@ jobs:
           chmod \
             +x \
             "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}"
+
           # Standardize binary name
           mv \
             "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" \
             "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
+
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.SHFMT_INSTALL_PATH }}" >>"$GITHUB_PATH"

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -105,15 +105,18 @@ jobs:
           git config \
             --global \
             user.email "bot@arduino.cc"
+
           git config \
             --global \
             user.name "ArduinoBot"
+
           git fetch \
             --no-tags \
             --prune \
             --depth=1 \
             origin \
             +refs/heads/gh-pages:refs/remotes/origin/gh-pages
+
           poetry run \
             mike deploy \
               --update-aliases \

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -115,11 +115,14 @@ jobs:
           security create-keychain \
             -p "${{ env.KEYCHAIN_PASSWORD }}" \
             "${{ env.KEYCHAIN }}"
+
           security default-keychain \
             -s "${{ env.KEYCHAIN }}"
+
           security unlock-keychain \
             -p "${{ env.KEYCHAIN_PASSWORD }}" \
             "${{ env.KEYCHAIN }}"
+
           security import \
             "${{ env.INSTALLER_CERT_MAC_PATH }}" \
             -k "${{ env.KEYCHAIN }}" \
@@ -127,6 +130,7 @@ jobs:
             -A \
             -T /usr/bin/codesign \
             -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+
           security set-key-partition-list \
             -S apple-tool:,apple: \
             -s \
@@ -142,6 +146,7 @@ jobs:
           unzip \
             gon_macos.zip \
             -d /usr/local/bin
+
       - name: Write gon config to file
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
@@ -179,14 +184,17 @@ jobs:
           chmod \
             +x \
             "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
+
           # Use of an array here is required for globbing
           PACKAGE_FILENAME=(${{ env.PROJECT_NAME }}_nightly-*${{ matrix.build.package-suffix }})
+
           tar \
             -czvf "$PACKAGE_FILENAME" \
             -C "${{ env.BUILD_FOLDER }}/" \
             "${{ env.PROJECT_NAME }}" \
             -C ../../ \
             LICENSE.txt
+
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Replace artifact with notarized build

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -151,9 +151,11 @@ jobs:
       - name: Create checksum file
         run: |
           TAG="${{ needs.package-name-prefix.outputs.prefix }}git-snapshot"
+
           declare \
             -a \
             artifacts=($(ls -d */))
+
           for artifact in ${artifacts[@]}; do
             cd $artifact
             checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -101,6 +101,7 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >>"$GITHUB_ENV"
+
           TAG="${GITHUB_REF/refs\/tags\//}"
           echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >>$GITHUB_ENV
 
@@ -121,14 +122,18 @@ jobs:
           KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode >"${{ env.INSTALLER_CERT_MAC_PATH }}"
+
           security create-keychain \
             -p "${{ env.KEYCHAIN_PASSWORD }}" \
             "${{ env.KEYCHAIN }}"
+
           security default-keychain \
             -s "${{ env.KEYCHAIN }}"
+
           security unlock-keychain \
             -p "${{ env.KEYCHAIN_PASSWORD }}" \
             "${{ env.KEYCHAIN }}"
+
           security import \
             "${{ env.INSTALLER_CERT_MAC_PATH }}" \
             -k "${{ env.KEYCHAIN }}" \
@@ -136,6 +141,7 @@ jobs:
             -A \
             -T "/usr/bin/codesign" \
             -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+
           security set-key-partition-list \
             -S apple-tool:,apple: \
             -s \
@@ -150,6 +156,7 @@ jobs:
           unzip \
             gon_macos.zip \
             -d /usr/local/bin
+
       - name: Write gon config to file
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
@@ -192,6 +199,7 @@ jobs:
             -C "${{ env.BUILD_FOLDER }}/" \
             "${{ env.PROJECT_NAME }}" \
             -C ../../ LICENSE.txt
+
       - name: Replace artifact with notarized build
         uses: actions/upload-artifact@v4
         with:
@@ -231,14 +239,17 @@ jobs:
             -q \
             -P /tmp \
             https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
+
           unzip \
             -p \
             /tmp/3.2.0.zip \
             semver-tool-3.2.0/src/semver \
           >/tmp/semver
+
           chmod \
             +x \
             /tmp/semver
+
           if [[ \
             "$(
               /tmp/semver get prerel \

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -77,6 +77,7 @@ jobs:
           mkdir \
             -p \
             "${{ env.BINDIR }}"
+
           "${{ github.workspace }}/etc/install.sh"
 
       - name: Verify installation


### PR DESCRIPTION
The `run` keys of the steps in the GitHub Actions workflows contain complex shell command lines.

The readability of this code is improved by selectively adding blank lines to separate it visually into logical groupings.