### PR TITLE
Update redirecting URLs in reference links

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+# See: https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference#about-the-dependabotyml-file
 version: 2
 
 updates:

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-certificates.md
 name: Check Certificates
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Set certificate path environment variable
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "CERTIFICATE_PATH=${{ runner.temp }}/certificate.p12" >>"$GITHUB_ENV"
 
       - name: Decode certificate

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
 name: Check General Formatting
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >>"$GITHUB_ENV"
 
       - name: Checkout repository
@@ -82,7 +82,7 @@ jobs:
             "${{ env.EC_INSTALL_PATH }}/bin/ec"
 
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#adding-a-system-path
           echo "${{ env.EC_INSTALL_PATH }}/bin" >>"$GITHUB_PATH"
 
       - name: Check formatting

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md
 name: Check Go Dependencies
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-task.md
 name: Check Go
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
 name: Check License
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
 name: Check Markdown
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-mkdocs-task.yml
+++ b/.github/workflows/check-mkdocs-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-mkdocs-task.md
 name: Check Website
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-npm-task.md
 name: Check npm
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
 name: Check Prettier Formatting
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-python-task.md
 name: Check Python
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-shell-task.md
 name: Check Shell Scripts
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >>"$GITHUB_ENV"
 
       - name: Checkout repository
@@ -117,7 +117,7 @@ jobs:
           )"
 
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >>"$GITHUB_PATH"
 
       - name: Run ShellCheck
@@ -148,7 +148,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >>"$GITHUB_ENV"
 
       - name: Checkout repository
@@ -182,7 +182,7 @@ jobs:
             "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
 
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#adding-a-system-path
           echo "${{ env.SHFMT_INSTALL_PATH }}" >>"$GITHUB_PATH"
 
       - name: Format shell scripts

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-workflows-task.md
 name: Check Workflows
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -11,7 +11,7 @@ env:
   AWS_REGION: "us-east-1"
   ARTIFACT_PREFIX: dist-
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   schedule:
     # run every day at 1AM
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >>"$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/publish-go-tester-task.md
 name: Publish Tester Build
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >>"$GITHUB_ENV"
 
           TAG="${GITHUB_REF/refs\/tags\//}"

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md
 name: Spell Check
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels-npm.md
 name: Sync Labels
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   push:
     paths:
@@ -102,7 +102,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >>"$GITHUB_ENV"
 
       - name: Determine whether to dry run

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-integration-task.md
 name: Test Integration
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-task.md
 name: Test Go
 
-# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+# See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -13,7 +13,7 @@ on:
     # Run every day at 03:00 UTC to catch breakage caused by external events
     - cron: "0 3 * * *"
   # workflow_dispatch event allows the workflow to be triggered manually.
-  # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
+  # See: https://docs.github.com/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
 
 env:
@@ -65,7 +65,7 @@ jobs:
       - name: Set install path environment variable
         shell: bash
         run: |
-          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable
           echo "BINDIR=${{ runner.temp }}/custom-installation-folder" >>"$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/main/docs/configuration.md
+# See: https://github.com/licensee/licensed/blob/main/docs/configuration.md
 sources:
   go: true
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -195,7 +195,7 @@ tasks:
             echo "Please use Linux/macOS or download the dependencies cache from the GitHub Actions workflow artifact."
           else
             echo "licensed not found or not in PATH."
-            echo "Please install: https://github.com/github/licensed#as-an-executable"
+            echo "Please install: https://github.com/licensee/licensed#installation"
           fi
           exit 1
         fi


### PR DESCRIPTION
The templates and documentation contain reference links to provide additional information to the users and maintainers.

The targets of some of these links have moved since the time they were added. Although the user could still reach the intended content via a redirect, it is best not to rely on redirects continuing to work indefinitely. So the URLs are hereby updated to point directly to the target content.