### PR TITLE
Correct syntax of shell code in "Check Certificates" workflow

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -172,9 +172,9 @@ jobs:
             )"
           fi
 
-          DAYS_BEFORE_EXPIRATION="$(
-            (($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24)
-          )"
+          DAYS_BEFORE_EXPIRATION="$((
+            ($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24
+          ))"
 
           # Display the expiration information in the log.
           echo "Certificate expiration date: $EXPIRATION_DATE"


### PR DESCRIPTION
Previously, the command was erroneously split at the first parenthesis. This resulted in the introduction of spaces between the two parentheses, which caused the syntax to be interpreted as a command substitution operator instead of the intended arithmetic expansion operator. This caused the command to fail:

```
/home/runner/work/_temp/2470dde2-826c-4a00-8268-b8d111566dc2.sh: line 46: syntax error near unexpected token `/'
```