### PR TITLE
Simplify workflow code

### DIFF
--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -127,8 +127,7 @@ jobs:
           linters: gcc
           # Due to a quirk of the "liskin/gh-problem-matcher-wrap" action, the entire command must be on a single line
           # (instead of being broken into multiple lines for readability).
-          run: |
-            task --silent shell:check SCRIPT_PATH="${{ matrix.script }}" SHELLCHECK_FORMAT=${{ matrix.configuration.format }}
+          run: task --silent shell:check SCRIPT_PATH="${{ matrix.script }}" SHELLCHECK_FORMAT=${{ matrix.configuration.format }}
 
   formatting:
     name: formatting (${{ matrix.script }})


### PR DESCRIPTION
Previously, a "block scalar" was used in the workflow. This is useful in the case of a multi-line string. However, this string is only a single line. Although it would be useful to break the command up into multiple lines via the use of the line continuation operators, this is not possible due to a quirk of the action. So the use of the "block scalar" is not really beneficial in this case. Furthermore, the use of the "block scalar" might encourage the maintainer to try to split the command into multiple lines as is common practice for complex shell commands in the infrastructure, leading to wasted time.