### PR TITLE
Disable Poetry "package mode"

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -639,7 +639,7 @@ tasks:
     deps:
       - task: poetry:install
     cmds:
-      - poetry install --no-root
+      - poetry install
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:update-deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry/pyproject.toml
 
 [tool.poetry]
-name = "arduino-lint"
-version = "0.0.0"
-description = "arduino-lint"
-authors = ["Arduino <info@arduino.cc>"]
+package-mode = false
 
 # The dependencies in this group are installed using pipx; NOT Poetry. The use of the `tool.poetry.group` super-table
 # is a hack required in order to be able to manage updates of these dependencies via Dependabot.


### PR DESCRIPTION
The project's Python package dependencies are managed using the Poetry tool.

By default, Poetry is configured in "package mode", which is intended for use with projects that are a Python package. When Poetry is used in a project like this that is a standalone script, this configuration is inappropriate and has the following effects:

* `poetry install` command installs the project as a Python package in addition to the dependencies.
* `name`, `version`, `description`, and `authors` fields of the pyproject.toml file are required.

Installing the project as a package is completely inappropriate if the project is not a package, and may cause the command to fail with a cryptic error. This can be avoided by passing the `--no-root` flag to the `install` command, but that increases the usage complexity and chance for user error.

Although metadata fields under the `tool.poetry` section of the pyproject.toml configuration file are important for a package, in a non-package project there are better ways to provide that information. Since Git tags are used for versioning, the presence of a `version` field is especially harmful since it means duplication of information and extra work for the project maintainer (and likelihood the metadata will not be kept updated).

This "package mode" can be disabled via the pyproject.toml configuration file, which causes Poetry to operate purely in the sole capacity in which it is used by this project: to manage dependencies.