### PR TITLE
Configure task dependencies to avoid redundant execution

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -179,6 +179,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
   docs:generate:
     desc: Create all generated documentation content
+    run: when_changed
     deps:
       - task: go:cli-docs
       - task: go:rule-docs
@@ -495,6 +496,7 @@ tasks:
       Install dependencies managed by npm.
       Environment variable parameters:
       - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
+    run: when_changed
     dir: |
       "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
     cmds:


### PR DESCRIPTION
The "Task" task runner tool is used to perform common development operations for the project.

Tasks may call other tasks. Under certain conditions (most commonly when running a convenience "umbrella" which calls all tasks of a general type), this can result in the same task being called redundantly, which is inefficient. Worse, since task calls specified via the `deps` mapping of a task definition are executed concurrently, the multiple executions can conflict with each other and cause problems such as a spurious failure.

This can be avoided by configuring tasks which may be called multiple times, and for which it never makes sense to execute multiple times with the same conditions, so that all but the first call will be ignored.