### PR TITLE
Add source comments to reusable infrastructure components

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm/.npmrc
 # See: https://docs.npmjs.com/cli/configuring-npm/npmrc
 
 engine-strict=true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,7 @@ vars:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/release-go-task/Taskfile.yml
   PROJECT_NAME: "arduino-lint"
   DIST_DIR: "dist"
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   # Path of the project's primary Go module:
   DEFAULT_GO_MODULE_PATH: .
   DEFAULT_GO_PACKAGES: |


### PR DESCRIPTION
The project infrastructure uses reusable components that are maintained in a centralized repository. Documenting the source of these components facilitates maintenance, either by pulling in changes made upstream, or pushing locally implemented changes back upstream.