### PR TITLE
Bump github.com/ulikunitz/xz from 0.5.14 to 0.5.15

### DIFF
--- a/.licenses/arduino-lint/go/github.com/ulikunitz/xz.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/ulikunitz/xz.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/ulikunitz/xz
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package xz supports the compression and decompression of xz files.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz

--- a/.licenses/arduino-lint/go/github.com/ulikunitz/xz/internal/hash.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/ulikunitz/xz/internal/hash.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/ulikunitz/xz/internal/hash
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package hash provides rolling hashes.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/internal/hash
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/arduino-lint/go/github.com/ulikunitz/xz/internal/xlog.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/ulikunitz/xz/internal/xlog.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: github.com/ulikunitz/xz/internal/xlog
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package xlog provides a simple logging package that allows to disable certain
   message categories.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/internal/xlog
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/arduino-lint/go/github.com/ulikunitz/xz/lzma.dep.yml
+++ b/.licenses/arduino-lint/go/github.com/ulikunitz/xz/lzma.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/ulikunitz/xz/lzma
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package lzma supports the decoding and encoding of LZMA streams.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/lzma
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/docsgen/go/github.com/ulikunitz/xz.dep.yml
+++ b/.licenses/docsgen/go/github.com/ulikunitz/xz.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/ulikunitz/xz
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package xz supports the compression and decompression of xz files.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz

--- a/.licenses/docsgen/go/github.com/ulikunitz/xz/internal/hash.dep.yml
+++ b/.licenses/docsgen/go/github.com/ulikunitz/xz/internal/hash.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/ulikunitz/xz/internal/hash
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package hash provides rolling hashes.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/internal/hash
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/docsgen/go/github.com/ulikunitz/xz/internal/xlog.dep.yml
+++ b/.licenses/docsgen/go/github.com/ulikunitz/xz/internal/xlog.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: github.com/ulikunitz/xz/internal/xlog
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package xlog provides a simple logging package that allows to disable certain
   message categories.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/internal/xlog
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/docsgen/go/github.com/ulikunitz/xz/lzma.dep.yml
+++ b/.licenses/docsgen/go/github.com/ulikunitz/xz/lzma.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/ulikunitz/xz/lzma
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package lzma supports the decoding and encoding of LZMA streams.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/lzma
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/ruledocsgen/go/github.com/ulikunitz/xz.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/ulikunitz/xz.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/ulikunitz/xz
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package xz supports the compression and decompression of xz files.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz

--- a/.licenses/ruledocsgen/go/github.com/ulikunitz/xz/internal/hash.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/ulikunitz/xz/internal/hash.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/ulikunitz/xz/internal/hash
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package hash provides rolling hashes.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/internal/hash
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/ruledocsgen/go/github.com/ulikunitz/xz/internal/xlog.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/ulikunitz/xz/internal/xlog.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: github.com/ulikunitz/xz/internal/xlog
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package xlog provides a simple logging package that allows to disable certain
   message categories.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/internal/xlog
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/.licenses/ruledocsgen/go/github.com/ulikunitz/xz/lzma.dep.yml
+++ b/.licenses/ruledocsgen/go/github.com/ulikunitz/xz/lzma.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/ulikunitz/xz/lzma
-version: v0.5.14
+version: v0.5.15
 type: go
 summary: Package lzma supports the decoding and encoding of LZMA streams.
 homepage: https://pkg.go.dev/github.com/ulikunitz/xz/lzma
 license: bsd-3-clause
 licenses:
-- sources: xz@v0.5.14/LICENSE
+- sources: xz@v0.5.15/LICENSE
   text: |
     Copyright (c) 2014-2022  Ulrich Kunitz
     All rights reserved.

--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/sqs/goreturns v0.0.0-20181028201513-538ac6014518 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/ulikunitz/xz v0.5.14 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/docsgen/go.sum
+++ b/docsgen/go.sum
@@ -1279,8 +1279,8 @@ github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/Aaua
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/ulikunitz/xz v0.5.14 h1:uv/0Bq533iFdnMHZdRBTOlaNMdb1+ZxXIlHDZHIHcvg=
-github.com/ulikunitz/xz v0.5.14/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/unrolled/secure v0.0.0-20180918153822-f340ee86eb8b/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/unrolled/secure v0.0.0-20181005190816-ff9db2ff917f/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/spf13/viper v1.17.0 // indirect
 	github.com/sqs/goreturns v0.0.0-20181028201513-538ac6014518 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/ulikunitz/xz v0.5.14 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.bug.st/cleanup v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1303,8 +1303,8 @@ github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/Aaua
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/ulikunitz/xz v0.5.14 h1:uv/0Bq533iFdnMHZdRBTOlaNMdb1+ZxXIlHDZHIHcvg=
-github.com/ulikunitz/xz v0.5.14/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/unrolled/secure v0.0.0-20180918153822-f340ee86eb8b/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/unrolled/secure v0.0.0-20181005190816-ff9db2ff917f/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/ruledocsgen/go.mod
+++ b/ruledocsgen/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/spf13/viper v1.17.0 // indirect
 	github.com/sqs/goreturns v0.0.0-20181028201513-538ac6014518 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/ulikunitz/xz v0.5.14 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/ruledocsgen/go.sum
+++ b/ruledocsgen/go.sum
@@ -1283,8 +1283,8 @@ github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/Aaua
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/ulikunitz/xz v0.5.14 h1:uv/0Bq533iFdnMHZdRBTOlaNMdb1+ZxXIlHDZHIHcvg=
-github.com/ulikunitz/xz v0.5.14/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/unrolled/secure v0.0.0-20180918153822-f340ee86eb8b/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/unrolled/secure v0.0.0-20181005190816-ff9db2ff917f/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=


### PR DESCRIPTION
This is necessary to fix a regression introduced by 0.5.14, which caused builds for 32-bit hosts to fail:

```text
/go/pkg/mod/github.com/ulikunitz/xz@v0.5.14/lzma/reader.go:33:15: cannot use 1 << 31 (untyped int constant 2147483648) as int value in assignment (overflows)
Error: failed building for linux/armv6: exit status 1
failed building for linux/armv6: exit status 1
task: Failed to run task "dist:Linux_ARMv6": exit status 1
```