### PR TITLE
Fix macOS Apple Silicon release builds

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   create-nightly-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -30,22 +30,31 @@ jobs:
         os:
           - task: Windows_32bit
             artifact-suffix: Windows_32bit
+            runner: ubuntu-latest
           - task: Windows_64bit
             artifact-suffix: Windows_64bit
+            runner: ubuntu-latest
           - task: Linux_32bit
             artifact-suffix: Linux_32bit
+            runner: ubuntu-latest
           - task: Linux_64bit
             artifact-suffix: Linux_64bit
+            runner: ubuntu-latest
           - task: Linux_ARMv6
             artifact-suffix: Linux_ARMv6
+            runner: ubuntu-latest
           - task: Linux_ARMv7
             artifact-suffix: Linux_ARMv7
+            runner: ubuntu-latest
           - task: Linux_ARM64
             artifact-suffix: Linux_ARM64
+            runner: ubuntu-latest
           - task: macOS_64bit
             artifact-suffix: macOS_64bit
+            runner: ubuntu-latest
           - task: macOS_ARM64
             artifact-suffix: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -78,7 +78,7 @@ jobs:
   build:
     needs: package-name-prefix
     name: Build ${{ matrix.os.artifact-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -87,30 +87,39 @@ jobs:
         os:
           - task: Windows_32bit
             path: "*Windows_32bit.zip"
+            runner: ubuntu-latest
             artifact-name: Windows_X86-32
           - task: Windows_64bit
             path: "*Windows_64bit.zip"
+            runner: ubuntu-latest
             artifact-name: Windows_X86-64
           - task: Linux_32bit
             path: "*Linux_32bit.tar.gz"
+            runner: ubuntu-latest
             artifact-name: Linux_X86-32
           - task: Linux_64bit
             path: "*Linux_64bit.tar.gz"
+            runner: ubuntu-latest
             artifact-name: Linux_X86-64
           - task: Linux_ARMv6
             path: "*Linux_ARMv6.tar.gz"
+            runner: ubuntu-latest
             artifact-name: Linux_ARMv6
           - task: Linux_ARMv7
             path: "*Linux_ARMv7.tar.gz"
+            runner: ubuntu-latest
             artifact-name: Linux_ARMv7
           - task: Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
+            runner: ubuntu-latest
             artifact-name: Linux_ARM64
           - task: macOS_64bit
             path: "*macOS_64bit.tar.gz"
+            runner: ubuntu-latest
             artifact-name: macOS_64
           - task: macOS_ARM64
             path: "*macOS_ARM64.tar.gz"
+            runner: ubuntu-24.04-arm
             artifact-name: macOS_ARM64
 
     steps:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   create-release-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -27,22 +27,31 @@ jobs:
         os:
           - task: Windows_32bit
             artifact-suffix: Windows_32bit
+            runner: ubuntu-latest
           - task: Windows_64bit
             artifact-suffix: Windows_64bit
+            runner: ubuntu-latest
           - task: Linux_32bit
             artifact-suffix: Linux_32bit
+            runner: ubuntu-latest
           - task: Linux_64bit
             artifact-suffix: Linux_64bit
+            runner: ubuntu-latest
           - task: Linux_ARMv6
             artifact-suffix: Linux_ARMv6
+            runner: ubuntu-latest
           - task: Linux_ARMv7
             artifact-suffix: Linux_ARMv7
+            runner: ubuntu-latest
           - task: Linux_ARM64
             artifact-suffix: Linux_ARM64
+            runner: ubuntu-latest
           - task: macOS_64bit
             artifact-suffix: macOS_64bit
+            runner: ubuntu-latest
           - task: macOS_ARM64
             artifact-suffix: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The `docker.elastic.co/beats-dev/golang-crossbuild:1.24.0-darwin-arm64-debian10` container is used for the release builds for the macOS Apple Silicon host. This container will only run on hosts of the linux/arm64 architecture.

The GitHub Actions runner machine previously used to perform the release builds is of the linux/amd64 architecture and so is not compatible with the container. This caused the release builds to fail:

```text
Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.24.0-darwin-arm64-debian10
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
exec /crossbuild: exec format error
task: Failed to run task "dist:macOS_ARM64": exit status 255
```

The failure is resolved by configuring the release workflows to use the `ubuntu-24.04-arm` runner machine that is compatible with the container.

The standard practice is to use the "latest" GitHub Actions runner identifiers, which causes the workflow runs to always use the newest stable runner version. However, GitHub has broken from this established convention by refusing to provide "latest" identifiers for the Linux ARM runners. For this reason, the version-specific runner name was used in the workflow. It will be necessary to manually update the runner name as new stable versions are made available (or more likely after the removal of the runner in use breaks the workflows).

---

Related: https://github.com/arduino/arduino-cli/pull/2896