### PR TITLE
Remove vestigial "to do" comment from workflow

### DIFF
--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -97,7 +97,6 @@ jobs:
       fail-fast: false
       matrix:
         project:
-          # TODO: add paths of all npm-managed projects in the repository here.
           - path: .
 
     steps:


### PR DESCRIPTION
This workflow came from a collection of reusable infrastructure assets. This comment is intended to facilitate project-specific configuration at the time of installation in a project. It serves no purpose after installation and thus should have been removed at that time.