### PR TITLE
Remove `poetry:update-deps` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -687,14 +687,6 @@ tasks:
         poetry lock \
           --no-cache
 
-  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
-  poetry:update-deps:
-    desc: Update all dependencies managed by Poetry to their newest versions
-    deps:
-      - task: poetry:install
-    cmds:
-      - poetry update
-
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-poetry-task/Taskfile.yml
   poetry:validate:
     desc: Validate Poetry configuration


### PR DESCRIPTION
This task updates all the project's Python package dependencies to the latest version.

Performing bulk updates is not a good practice, since it is non-atomic and thus makes it difficult to bisect regressions caused by the update. In addition, it is not necessary since dependencies are now updated using Dependabot.

For these reasons, the task is harmful and superfluous.