### PR TITLE
Use Go tool system to manage "go-bindata" tool dependency

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -334,9 +334,24 @@ tasks:
   go:generate:
     desc: Generate Go code
     cmds:
-      - go install "github.com/go-bindata/go-bindata/...@v3.1.1"
-      - go-bindata -nocompress -nometadata -o "./internal/rule/schema/schemadata/bindata.go" --pkg schemadata --prefix "./etc/schemas/" "./etc/schemas/"
-      - go-bindata -nocompress -nometadata -o "./internal/rule/schema/testdata/bindata.go" --pkg testdata --prefix "./internal/rule/schema/testdata/input/" "./internal/rule/schema/testdata/input/"
+      - |
+        go tool \
+          github.com/go-bindata/go-bindata/go-bindata \
+            -nocompress \
+            -nometadata \
+            -o "./internal/rule/schema/schemadata/bindata.go" \
+            --pkg schemadata \
+            --prefix "./etc/schemas/" \
+            "./etc/schemas/"
+      - |
+        go tool \
+          github.com/go-bindata/go-bindata/go-bindata \
+            -nocompress \
+            -nometadata \
+            -o "./internal/rule/schema/testdata/bindata.go" \
+            --pkg testdata \
+            --prefix "./internal/rule/schema/testdata/input/" \
+            "./internal/rule/schema/testdata/input/"
       - go install golang.org/x/tools/cmd/stringer@v0.25.0
       - go generate ./...
       - task: go:format

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/go-bindata/go-bindata v3.1.1+incompatible // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
@@ -148,6 +149,7 @@ require (
 )
 
 tool (
+	github.com/go-bindata/go-bindata/go-bindata
 	github.com/go-task/task/v3/cmd/task
 	github.com/mikefarah/yq/v4
 )

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,7 @@ github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-bindata/go-bindata v3.1.1+incompatible h1:tR4f0e4VTO7LK6B2YWyAoVEzG9ByG1wrXB4TL9+jiYg=
 github.com/go-bindata/go-bindata v3.1.1+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=


### PR DESCRIPTION
The [**go-bindata**](https://github.com/go-bindata/go-bindata) tool is used to embed the JSON schemas used by Arduino Lint's rules as Go code, allowing the tool installation to consist of a single executable file.

Previously, the tool was installed via a `go install` command in the task. This approach is problematic for several reasons:

- It installs the tool globally (in `GOBIN`), and thus pollutes the contributor's global environment
- The tool must be updated manually

Since **go-bindata** is a Go module-based tool, it can be installed and managed by using the Go modules system, which has explicit support for tool dependencies as of the Go 1.24 release.

This will allow keeping the dependency updated via the Dependabot service, just as is done with the Go module dependencies of the codebase, and other tool dependencies.