### PR TITLE
Wrap signing certificate password in single quotes to prevent corruption

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -140,7 +140,7 @@ jobs:
             -f pkcs12 \
             -A \
             -T /usr/bin/codesign \
-            -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+            -P '${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}'
 
           security set-key-partition-list \
             -S apple-tool:,apple: \

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -150,7 +150,7 @@ jobs:
             -f pkcs12 \
             -A \
             -T "/usr/bin/codesign" \
-            -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+            -P '${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}'
 
           security set-key-partition-list \
             -S apple-tool:,apple: \


### PR DESCRIPTION
Wrap signing certificate password in single quotes to prevent corruption

High quality passwords may contain characters with special treatment by the shell (e.g., $).

The release workflows contain a command that imports the macOS code signing certificate to the runner machine's keychain. The command references a GitHub Actions secret that contains the password of the certificate.

Previously, that reference was wrapped in double quotes. This resulted in the password string being subject to shell expansions. If the password contained characters that incidentally resemble shell code, this resulted in the corruption of the password, nd thus a spurious failure of the release workflow:

```text
security: SecKeychainItemImport: The user name or passphrase you entered is not correct.
```