### PR TITLE
Update project Go version to 1.24.8

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -48,7 +48,7 @@ jobs:
             runner: ubuntu-latest
           - task: Linux_ARM64
             artifact-suffix: Linux_ARM64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
           - task: macOS_64bit
             artifact-suffix: macOS_64bit
             runner: ubuntu-latest

--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -111,7 +111,7 @@ jobs:
             artifact-name: Linux_ARMv7
           - task: Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
             artifact-name: Linux_ARM64
           - task: macOS_64bit
             path: "*macOS_64bit.tar.gz"

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -45,7 +45,7 @@ jobs:
             runner: ubuntu-latest
           - task: Linux_ARM64
             artifact-suffix: Linux_ARM64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
           - task: macOS_64bit
             artifact-suffix: macOS_64bit
             runner: ubuntu-latest

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -19,7 +19,7 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.24.0"
+  GO_VERSION: "1.24.8"
 
 tasks:
   Windows_32bit:
@@ -219,13 +219,14 @@ tasks:
     desc: Builds Linux ARM64 binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
           -e CGO_ENABLED=0 \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-          --build-cmd "{{.BUILD_COMMAND}}" \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
 
         tar cz \
@@ -239,7 +240,7 @@ tasks:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/arm64"
-      CONTAINER_TAG: "{{.GO_VERSION}}-arm"
+      CONTAINER_TAG: "{{.GO_VERSION}}-base-arm-debian10"
       PACKAGE_PLATFORM: "Linux_ARM64"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -434,7 +434,7 @@ tasks:
       - GO_MODULE_PATH: Path of the Go module root (default: {{.DEFAULT_GO_MODULE_PATH}}).
     dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     vars:
-      GO_VERSION: 1.24.0
+      GO_VERSION: 1.24.8
     cmds:
       - go mod tidy -compat={{.GO_VERSION}}
 

--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -1,7 +1,7 @@
 // Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/cobra/docsgen/go.mod
 module github.com/arduino/arduino-lint/docsgen
 
-go 1.24.0
+go 1.24.8
 
 replace github.com/arduino/arduino-lint => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-lint
 
-go 1.24.0
+go 1.24.8
 
 replace github.com/jandelgado/gcov2lcov => github.com/jandelgado/gcov2lcov v1.0.5 // v1.0.4 causes Dependabot updates to fail due to checksum mismatch (likely a moved tag). This is an unused transitive dependency, so version is irrelevant.
 

--- a/ruledocsgen/go.mod
+++ b/ruledocsgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-lint/ruledocsgen
 
-go 1.24.0
+go 1.24.8
 
 replace github.com/arduino/arduino-lint => ../
 


### PR DESCRIPTION
Several changes were required to accompany the version number bumps:

Image Name
----------

It was necessary to change the format of the name of the image used for the Linux ARM 64-bit release builds from:

`docker.elastic.co/beats-dev/golang-crossbuild:1.24.0-arm`

to:

`docker.elastic.co/beats-dev/golang-crossbuild:1.24.8-base-arm-debian10`

This is due to an change in the `docker.elastic.co/beats-dev/golang-crossbuild` image naming scheme, starting from 1.24.1 (https://github.com/elastic/golang-crossbuild/issues/545, https://github.com/elastic/golang-crossbuild/issues/639).

Without the change, the build would fail:

```
docker: Error response from daemon: manifest for docker.elastic.co/beats-dev/golang-crossbuild:1.24.8-arm not found: manifest unknown: manifest unknown
```

Runner for Linux ARM 64-bit Release Builds
------------------------------------------

Previously, the `ubuntu-latest` GitHub Actions runner was used for the matrix job of the Linux ARM 64-bit release builds. However, the `docker.elastic.co/beats-dev/golang-crossbuild:1.24.8-base-arm-debian10` image fails to run on this runner:

```
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
exec /crossbuild: exec format error
```

The incompatibility is solved by changing to the Linux ARM runner `ubuntu-24.04-arm`, as was previously done to solve the same problem for the macOS ARM build (https://github.com/arduino/arduino-lint/pull/952).

It is standard practice to use the "latest" GitHub Actions runner identifiers in the project's workflows, which causes the workflow runs to always use the newest stable runner version. However, GitHub has broken from this established convention by choosing to not provide "latest" identifiers for the Linux ARM runners (https://github.com/actions/partner-runner-images/issues/118#issuecomment-3151859667). For this reason, the version-specific runner name was used in the workflow. It will be necessary to manually update the runner name as new stable versions are made available (or more likely fail to do so until forced after GitHub's removal of the runner in use breaks the workflows).