### PR TITLE
Improve version number regex in installation script

### DIFF
--- a/etc/install.sh
+++ b/etc/install.sh
@@ -84,7 +84,7 @@ initDownloadTool() {
 checkLatestVersion() {
   # Use the GitHub releases webpage to find the latest version for this project
   # so we don't get rate-limited.
-  CHECKLATESTVERSION_REGEX="[0-9][A-Za-z0-9\.-]*"
+  CHECKLATESTVERSION_REGEX="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9\.-]+)?"
   CHECKLATESTVERSION_LATEST_URL="https://github.com/${PROJECT_OWNER}/${PROJECT_NAME}/releases/latest"
   if [ "$DOWNLOAD_TOOL" = "curl" ]; then
     CHECKLATESTVERSION_TAG=$(curl -SsL $CHECKLATESTVERSION_LATEST_URL | grep --extended-regexp -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep --extended-regexp -o "$CHECKLATESTVERSION_REGEX")


### PR DESCRIPTION
The installation script scrapes the GitHub releases page for the version number of the latest release. A regular expression is used to extract the version number from the title.

Previously, the regular expression would return a corrupted version number if the name of the repository owner or repository contained numbers. For example, if used in a repository owned by GitHub user `per1234`, where the latest release version was 1.2.3, it would return the following version number:

```text
1.2.3
1234
```