### PR TITLE
Update project Go version to 1.25.2

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -19,7 +19,7 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.24.8"
+  GO_VERSION: "1.25.2"
 
 tasks:
   Windows_32bit:
@@ -307,9 +307,9 @@ tasks:
       # The reason seems that go 1.16.x use a macos API which is available since 10.12
       #    https://github.com/techknowlogick/xgo/issues/100#issuecomment-780894190
       #
-      # To compile it we need an SDK >=10.12 so we use the debian10 based container that
+      # To compile it we need an SDK >=10.12 so we use the debian12 based container that
       # has the SDK 10.14 installed.
-      CONTAINER_TAG: "{{.GO_VERSION}}-darwin-debian10"
+      CONTAINER_TAG: "{{.GO_VERSION}}-darwin-debian12"
       PACKAGE_PLATFORM: "macOS_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -434,7 +434,7 @@ tasks:
       - GO_MODULE_PATH: Path of the Go module root (default: {{.DEFAULT_GO_MODULE_PATH}}).
     dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     vars:
-      GO_VERSION: 1.24.8
+      GO_VERSION: 1.25.2
     cmds:
       - go mod tidy -compat={{.GO_VERSION}}
 

--- a/docsgen/go.mod
+++ b/docsgen/go.mod
@@ -1,7 +1,7 @@
 // Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/cobra/docsgen/go.mod
 module github.com/arduino/arduino-lint/docsgen
 
-go 1.24.8
+go 1.25.2
 
 replace github.com/arduino/arduino-lint => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-lint
 
-go 1.24.8
+go 1.25.2
 
 replace github.com/jandelgado/gcov2lcov => github.com/jandelgado/gcov2lcov v1.0.5 // v1.0.4 causes Dependabot updates to fail due to checksum mismatch (likely a moved tag). This is an unused transitive dependency, so version is irrelevant.
 

--- a/ruledocsgen/go.mod
+++ b/ruledocsgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/arduino-lint/ruledocsgen
 
-go 1.24.8
+go 1.25.2
 
 replace github.com/arduino/arduino-lint => ../
 


### PR DESCRIPTION
In addition to the version bump, it was necessary to change to the `debian12` variant of [the Docker image](https://github.com/elastic/golang-crossbuild) used for the macOS x86 release builds. With the previous `debian10` variant, the build for that specific host failed:

```text
In file included from /go/pkg/mod/github.com/arduino/arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/i18n/detect_cgo_darwin.go:23:
In file included from /usr/local/osxcross/bin/../SDK/MacOSX12.3.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:12:
/usr/local/osxcross/bin/../SDK/MacOSX12.3.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSBundle.h:91:143: error: function does not return NSString
- (NSAttributedString *)localizedAttributedStringForKey:(NSString *)key value:(nullable NSString *)value table:(nullable NSString *)tableName NS_FORMAT_ARGUMENT(1) NS_REFINED_FOR_SWIFT API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0));
                                                         ~~~~~~~~~~~~~~                                                                       ^                  ~
/usr/local/osxcross/bin/../SDK/MacOSX12.3.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObjCRuntime.h:103:48: note: expanded from macro 'NS_FORMAT_ARGUMENT'
        #define NS_FORMAT_ARGUMENT(A) __attribute__ ((format_arg(A)))
                                                      ^          ~
In file included from /go/pkg/mod/github.com/arduino/arduino-cli@v0.35.4-0.20241001142927-1f8d0f6c0dd3/i18n/detect_cgo_darwin.go:23:
In file included from /usr/local/osxcross/bin/../SDK/MacOSX12.3.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:130:
/usr/local/osxcross/bin/../SDK/MacOSX12.3.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLSession.h:500:168: error: expected ')'
- (void)readDataOfMinLength:(NSUInteger)minBytes maxLength:(NSUInteger)maxBytes timeout:(NSTimeInterval)timeout completionHandler:(void (^) (NSData * _Nullable_result data, BOOL atEOF, NSError * _Nullable error))completionHandler;
                                                                                                                                                                       ^
/usr/local/osxcross/bin/../SDK/MacOSX12.3.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLSession.h:500:141: note: to match this '('
- (void)readDataOfMinLength:(NSUInteger)minBytes maxLength:(NSUInteger)maxBytes timeout:(NSTimeInterval)timeout completionHandler:(void (^) (NSData * _Nullable_result data, BOOL atEOF, NSError * _Nullable error))completionHandler;
                                                                                                                                            ^
2 errors generated.
```