### PR TITLE
Skip publishing releases to AWS if credentials not configured

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -261,7 +261,13 @@ jobs:
       id-token: write # This is required for requesting the JWT
 
     steps:
+      - name: Determine whether publishing to AWS is possible
+        id: aws-determination
+        run: |
+          echo "publish=${{ secrets.AWS_ROLE_TO_ASSUME != '' }}" >>$GITHUB_OUTPUT
+
       - name: Download artifact
+        if: steps.aws-determination.outputs.publish == 'true'
         uses: actions/download-artifact@v6
         with:
           pattern: ${{ env.ARTIFACT_PREFIX }}*
@@ -269,6 +275,7 @@ jobs:
           path: ${{ env.DIST_DIR }}
 
       - name: configure aws credentials
+        if: steps.aws-determination.outputs.publish == 'true'
         uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -276,6 +283,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload release files on Arduino downloads servers
+        if: steps.aws-determination.outputs.publish == 'true'
         run: |
           aws s3 sync \
             ${{ env.DIST_DIR }} \

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -221,6 +221,11 @@ jobs:
       id-token: write # This is required for requesting the JWT
 
     steps:
+      - name: Determine whether publishing to AWS is possible
+        id: aws-determination
+        run: |
+          echo "publish=${{ secrets.AWS_ROLE_TO_ASSUME != '' }}" >>$GITHUB_OUTPUT
+
       - name: Download artifact
         uses: actions/download-artifact@v6
         with:
@@ -275,6 +280,7 @@ jobs:
           artifacts: ${{ env.DIST_DIR }}/*
 
       - name: configure aws credentials
+        if: steps.aws-determination.outputs.publish == 'true'
         uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -282,6 +288,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload release files on Arduino downloads servers
+        if: steps.aws-determination.outputs.publish == 'true'
         run: |
           aws s3 sync \
             ${{ env.DIST_DIR }} \


### PR DESCRIPTION
The "Release" and "Publish Nightly Build" workflows upload the generated build files to the AWS S3 bucket used by Arduino's downloads server.

The necessary credentials are configured in Arduino's repository. However, these workflows might be used in other contexts:

- by contributors validating proposed changes to the release infrastructure in their fork
- by hard forks of the project

In either case (especially the former), the fork owner is unlikely to be willing/able to set up the AWS infrastructure that would be needed to use this capability of the workflow.

Since these workflows also publish the builds to GitHub, the AWS upload is not essential to either 3rd party use case.

The workflow code is hereby configured to skip the AWS upload steps if the necessary credentials have not been configured in the repository. The existence of the `AWS_ROLE_TO_ASSUME` repository secret is used as the indicator of whether the credentials are configured. This will allow runs of the workflow in forks without the need to remove the AWS upload steps.