### PR TITLE
Define Apple Developer Program "team ID" via repository variable

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -180,7 +180,7 @@ jobs:
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+          AC_PROVIDER: ${{ vars.AC_PROVIDER }}
         run: |
           go tool \
             github.com/bearer/gon/cmd/gon "${{ env.GON_CONFIG_PATH }}"

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -180,7 +180,7 @@ jobs:
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+          AC_PROVIDER: ${{ vars.AC_PROVIDER }}
         run: |
           go tool \
             github.com/bearer/gon/cmd/gon "${{ env.GON_CONFIG_PATH }}"


### PR DESCRIPTION
The macOS builds generated by the release workflows are notarized. The Apple Developer Program "team ID" associated with the signing certificate is provided to the [**Gon**](https://github.com/Bearer/gon) notarization tool (which [refers to it as the "App Store Connect provider"](https://github.com/Bearer/gon/tree/v0.0.37#:~:text=App%20Store%20Connect%20provider)).

Previously, this was defined via a [GitHub Actions secret](https://docs.github.com/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). That implies it is secret information. However, the team ID is public information that can be seen by anyone simply by looking at the notarized application (e.g., using the macOS [**spctl**](https://ss64.com/mac/spctl.html) utility), so there is need to use a secret for purposes of protecting the information.

The reason use of a secret was chosen for this purpose when the notarization system was originally developed was simply that the only alternative at that time was hardcoding the information in the workflow. Since the workflow is intended to be generally applicable even in 3rd party projects (including forks of Arduino projects), whereas the signing credentials are specific to Arduino, it is better to define them separately from the workflow so that it can be used without modification (though unfortunately some hardcoding of such information ended up being introduced to the workflows at at later time).

Since that time, GitHub has introduced the [repository variable feature](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#creating-configuration-variables-for-a-repository), which is intended to configure repository-specific non-secret information. This is the appropriate mechanism for defining the team ID.

Use of secrets to store non-secret information should be avoided as these have a higher maintenance burden. Likewise, ambiguity about what is truly secret makes it difficult to understand the attack surface of a project's infrastructure, resulting in a lack of focus on the true attack vectors.