### PR TITLE
Define macOS code signing identity via AC_APPLICATION_IDENTITY environment variable

### DIFF
--- a/.github/workflows/publish-go-nightly-task.yml
+++ b/.github/workflows/publish-go-nightly-task.yml
@@ -165,9 +165,7 @@ jobs:
           source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
-          sign {
-            application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
-          }
+          sign {}
 
           # Ask Gon for zip output to force notarization process to take place.
           # The CI will ignore the zip output, using the signed binary only.
@@ -178,6 +176,7 @@ jobs:
 
       - name: Sign and notarize binary
         env:
+          AC_APPLICATION_IDENTITY: ${{ vars.AC_APPLICATION_IDENTITY }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_PROVIDER: ${{ vars.AC_PROVIDER }}

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -165,9 +165,7 @@ jobs:
           source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
-          sign {
-            application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
-          }
+          sign {}
 
           # Ask Gon for zip output to force notarization process to take place.
           # The CI will ignore the zip output, using the signed binary only.
@@ -178,6 +176,7 @@ jobs:
 
       - name: Sign and notarize binary
         env:
+          AC_APPLICATION_IDENTITY: ${{ vars.AC_APPLICATION_IDENTITY }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_PROVIDER: ${{ vars.AC_PROVIDER }}


### PR DESCRIPTION
The release workflows use the [**Gon**](https://github.com/Bearer/gon) tool to sign and notarize the macOS builds.

The signing identity of the code signing certificate must be [provided to the tool](https://github.com/Bearer/gon/tree/v0.0.37#:~:text=The%20name%20or%20ID%20of%20the%20%22Developer%20ID%20Application%22%20certificate). Previously, this was hardcoded into the workflows. That was not ideal because the workflows are intended to be generally applicable to any project, including 3rd party projects which will have a different signing identity from that of Arduino's certificates.

In addition to posing an inconvenience to hard forks, the previous hardcoding also made it more difficult for community contributors to validate changes to the release system in their fork in preparation for submitting a pull request to Arduino's repository.

In addition to the configuration file that was previously used to configure the identity, **Gon** supports configuration via environment variables. Environment variables are already used for the other certificate-specific configuration. The reason an environment variable was not done for the identity is simply that Gon did not have support for doing so at the time the notarization system was developed. However, it is supported from version 0.0.28 (https://github.com/Bearer/gon/commit/c3c48ad3d44bbe7d5e7831ff6d91c1c16a182f0c).

Since this is public information, a [repository variable](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#creating-configuration-variables-for-a-repository) (as opposed to the [GitHub Actions secrets mechanism](https://docs.github.com/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) used by the workflow for the non-public data) is used to configure the identity via the repository settings. This will make it possible to run the workflow with any suitable certificate and credentials, without any changes to the workflow code.

---

Even though it no longer contains any data, it was necessary to leave the empty [`sign` block](https://github.com/Bearer/gon/tree/v0.0.37?tab=readme-ov-file#configuration-file:~:text=as%20a%20default.-,sign,-%2D%20Settings%20related%20to) in the **Gon** configuration file, as the presence of this block is required by the tool:

```text
❗️ `sign` configuration required with `source` set
When you set the `source` configuration, you must also specify the
`sign` configuration to sign the input files.
```