### PR TITLE
Add Node.js installation step to "Deploy Website" workflow

### DIFF
--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -67,6 +67,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
       - name: Install Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
The project documentation website contains some content generated from the codebase. The generated Markdown is formatted in order to ensure it aligns with the code style of the repository's human created Markdown content. The tool used for that formatting is Prettier. This tool dependency is managed via the npm package manager.

The generation is performed on demand by the website deployment workflow. Previously, the workflow did not perform an explicit Node.js installation, but rather relied on the runner machine to provide the npm dependency. An update to the version of Node.js preinstalled in the runner machine caused it to no longer provide that dependency, resulting in a failure of the workflow:

```text
task: [npm:install-deps] npm install
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: undefined
npm error notsup Not compatible with your version of node/npm: undefined
npm error notsup Required: {"node":"20.x"}
npm error notsup Actual:   {"npm":"10.9.8","node":"v22.22.3"}
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-06-07T03_55_21_134Z-debug-0.log
```

The naive solution would be to update the project Node.js version to the version 22 now preinstalled in the runner. It is true that an update from the outdated Node.js 20 is needed. However, this event exposes the fragility of the previous workflow design. For stability, the workflow should explicitly install all dependencies.