### PR TITLE
Bump project Node.js version to 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "prettier-plugin-toml": "2.0.6"
       },
       "engines": {
-        "node": "20.x"
+        "node": "24.x"
       }
     },
     "node_modules/@financial-times/origami-service-makefile": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prettier-plugin-toml": "2.0.6"
   },
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "type": "module"
 }


### PR DESCRIPTION
npm package-based tools are used for various development and maintenance operations for this project. In order to ensure these operations work as expected, the project is configured for a specific major version of Node.js to be used by the project infrastructure and collaborators.

The standard Node.js version for Arduino Tooling projects is now 24.